### PR TITLE
Added mocha and jasmine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ If nothing is provided as `preset` **default** is used.
  - *test_path*: Path to the which will execute the tests when opened
    in a browser.
 
+ - *test_framework*: Specify test framework which will execute the tests.
+    We support qunit, jasmine and mocha.
+
  - *browsers*: A list of browsers on which tests are to be run.
 
 A sample configuration file:
@@ -43,6 +46,7 @@ A sample configuration file:
       "username": "<username>",
       "key": "<key>",
       "test_path": "relative/path/to/test/page",
+      "test_framework": "qunit/jasmine/mocha",
       "browsers":   [{
         "browser": "firefox",
         "browser_version": "15.0",

--- a/lib/_patch/jasmine-jsreporter.js
+++ b/lib/_patch/jasmine-jsreporter.js
@@ -1,0 +1,161 @@
+/*
+  This file is part of the Jasmine JSReporter project from Ivan De Marino.
+
+  Copyright (C) 2011 Ivan De Marino (aka detro, aka detronizator), http://blog.ivandemarino.me, ivan.de.marino@gmail.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL IVAN DE MARINO BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+(function () {
+    // Ensure that Jasmine library is loaded first
+    if (typeof jasmine === "undefined") {
+        throw new Error("[Jasmine JSReporter] 'Jasmine' library not found");
+    }
+
+    /**
+     * Calculate elapsed time, in Seconds.
+     * @param startMs Start time in Milliseconds
+     * @param finishMs Finish time in Milliseconds
+     * @return Elapsed time in Seconds */
+    function elapsedSec (startMs, finishMs) {
+        return (finishMs - startMs) / 1000;
+    }
+
+    /**
+     * Round an amount to the given number of Digits.
+     * If no number of digits is given, than '2' is assumed.
+     * @param amount Amount to round
+     * @param numOfDecDigits Number of Digits to round to. Default value is '2'.
+     * @return Rounded amount */
+    function round (amount, numOfDecDigits) {
+        numOfDecDigits = numOfDecDigits || 2;
+        return Math.round(amount * Math.pow(10, numOfDecDigits)) / Math.pow(10, numOfDecDigits);
+    }
+
+    /**
+     * Collect information about a Suite, recursively, and return a JSON result.
+     * @param suite The Jasmine Suite to get data from
+     */
+    function getSuiteData (suite) {
+        var suiteData = {
+                description : suite.description,
+                durationSec : 0,
+                specs: [],
+                suites: [],
+                passed: true
+            },
+            specs = suite.specs(),
+            suites = suite.suites(),
+            i, ilen;
+
+        // Loop over all the Suite's Specs
+        for (i = 0, ilen = specs.length; i < ilen; ++i) {
+            suiteData.specs[i] = {
+                description : specs[i].description,
+                durationSec : specs[i].durationSec,
+                passed : specs[i].results().passedCount === specs[i].results().totalCount,
+                skipped : specs[i].results().skipped,
+                passedCount : specs[i].results().passedCount,
+                failedCount : specs[i].results().failedCount,
+                totalCount : specs[i].results().totalCount
+            };
+            suiteData.passed = !suiteData.specs[i].passed ? false : suiteData.passed;
+            suiteData.durationSec += suiteData.specs[i].durationSec;
+        }
+
+        // Loop over all the Suite's sub-Suites
+        for (i = 0, ilen = suites.length; i < ilen; ++i) {
+            suiteData.suites[i] = getSuiteData(suites[i]); //< recursive population
+            suiteData.passed = !suiteData.suites[i].passed ? false : suiteData.passed;
+            suiteData.durationSec += suiteData.suites[i].durationSec;
+        }
+
+        // Rounding duration numbers to 3 decimal digits
+        suiteData.durationSec = round(suiteData.durationSec, 4);
+
+        return suiteData;
+    }
+
+    var JSReporter =  function () {
+    };
+
+    JSReporter.prototype = {
+        reportRunnerStarting: function (runner) {
+            // Nothing to do
+        },
+
+        reportSpecStarting: function (spec) {
+            // Start timing this spec
+            spec.startedAt = new Date();
+        },
+
+        reportSpecResults: function (spec) {
+            // Finish timing this spec and calculate duration/delta (in sec)
+            spec.finishedAt = new Date();
+            spec.durationSec = elapsedSec(spec.startedAt.getTime(), spec.finishedAt.getTime());
+        },
+
+        reportSuiteResults: function (suite) {
+            // Nothing to do
+        },
+
+        reportRunnerResults: function (runner) {
+            var suites = runner.suites(),
+                i, ilen;
+
+            // Attach results to the "jasmine" object to make those results easy to scrap/find
+            jasmine.runnerResults = {
+                suites: [],
+                durationSec : 0,
+                passed : true
+            };
+
+            // Loop over all the Suites
+            for (i = 0, ilen = suites.length; i < ilen; ++i) {
+                if (suites[i].parentSuite === null) {
+                    jasmine.runnerResults.suites[i] = getSuiteData(suites[i]);
+                    // If 1 suite fails, the whole runner fails
+                    jasmine.runnerResults.passed = !jasmine.runnerResults.suites[i].passed ? false : jasmine.runnerResults.passed;
+                    // Add up all the durations
+                    jasmine.runnerResults.durationSec += jasmine.runnerResults.suites[i].durationSec;
+                }
+            }
+
+            // Decorate the 'jasmine' object with getters
+            jasmine.getJSReport = function () {
+                if (jasmine.runnerResults) {
+                    return jasmine.runnerResults;
+                }
+                return null;
+            };
+            jasmine.getJSReportAsString = function () {
+                return JSON.stringify(jasmine.getJSReport());
+            };
+        }
+    };
+
+    // export public
+    jasmine.JSReporter = JSReporter;
+})();
+

--- a/lib/_patch/jasmine-plugin.js
+++ b/lib/_patch/jasmine-plugin.js
@@ -1,0 +1,39 @@
+(function(){
+  function countSpecs(suite, results){
+    suite.specs.forEach(function(s){
+      if(s.passed){
+	results.passed++;
+      }else{
+	results.tracebacks.push(s.description);
+	results.failed++;
+      }
+    });
+    suite.suites.forEach(function(s){
+      results = countSpecs(s, results);
+    });
+    return(results);
+  }
+
+  var checker = setInterval(function(){
+    if(!jasmine.running){
+      var results = {}
+      var report = jasmine.getJSReport()
+      var errors = [];
+      results.runtime = report.durationSec * 1000;
+      results.total=0;
+      results.passed=0;
+      results.failed=0;
+      results.tracebacks=[];
+
+      jasmine.getJSReport().suites.forEach(function(suite){
+	results = countSpecs(suite, results);
+      });
+      results.total = results.passed + results.failed;
+
+      results.url = window.location.pathname;
+      BrowserStack.post("/_report", results, function(){});
+    }
+    clearInterval(checker);
+  }, 1000);
+})();
+

--- a/lib/_patch/mocha-plugin.js
+++ b/lib/_patch/mocha-plugin.js
@@ -1,0 +1,64 @@
+(function(){
+  function stack(err) {
+    var str = err.stack || err.toString();
+
+    if (!~str.indexOf(err.message)) {
+      str = err.message + '\n' + str;
+    }
+
+    if ('[object Error]' == str) {
+      str = err.message;
+    }
+
+    if (!err.stack && err.sourceURL && err.line !== undefined) {
+      str += '\n(' + err.sourceURL + ':' + err.line + ')';
+    }
+    return str.replace(/^/gm, '  ');
+  }
+
+  function title(test) {
+    return test.fullTitle().replace(/#/g, '');
+  }
+
+  return Mocha.BrowserStack = function (runner, root) {
+    Mocha.reporters.HTML.call(this, runner, root);
+
+    var count = 1,
+    that = this,
+    failures = 0,
+    passes = 0,
+    start = 0,
+    tracebacks = [];
+
+    runner.on('start', function () {
+      start = (new Date).getTime();
+    });
+    
+    runner.on('test end', function (test) {
+      count += 1;
+    });
+    
+    runner.on('pass', function (test) {
+      passes += 1;
+    });
+    
+    runner.on('fail', function (test, err) {
+      failures += 1;
+      
+      if (err) {
+	tracebacks.push(err);
+      }
+    });
+    
+    runner.on('end', function () {
+      results = {}
+      results.runtime = ((new Date).getTime() - start);
+      results.total = passes + failures;
+      results.passed = passes;
+      results.failed = failures;
+      results.tracebacks = tracebacks;
+      results.url = window.location.pathname;
+      BrowserStack.post("/_report", results, function(){});
+    });
+  };
+})();

--- a/lib/server.js
+++ b/lib/server.js
@@ -52,8 +52,12 @@ exports.Server = function Server(bsClient, workers) {
         scripts = [
           'json2.js',
           'browserstack.js',
-          'qunit-plugin.js'
         ]
+
+        framework_scripts = {'qunit': ['qunit-plugin.js'],
+			     'jasmine': ['jasmine-jsreporter.js', 'jasmine-plugin.js'],
+			     'mocha': ['mocha-plugin.js']
+			    }
 
         if (mimeType === 'text/html') {
           var matcher = /(.*)<\/body>/;
@@ -61,6 +65,23 @@ exports.Server = function Server(bsClient, workers) {
           scripts.forEach(function (script) {
             patch += "<script type='text/javascript' src='/_patch/" + script + "'></script>\n";
           });
+
+	  // adding framework scripts
+	  if(config['test_framework'] && config['test_framework']=="jasmine"){
+	    framework_scripts['jasmine'].forEach(function (script) {
+	      patch += "<script type='text/javascript' src='/_patch/" + script + "'></script>\n";
+	    });
+	    patch +="<script type='text/javascript'>jasmine.getEnv().addReporter(new jasmine.JSReporter());</script>\n";
+	  }else if(config['test_framework'] && config['test_framework']=="mocha"){
+	    framework_scripts['mocha'].forEach(function (script) {
+	      patch += "<script type='text/javascript' src='/_patch/" + script + "'></script>\n";
+	    });
+	    patch +="<script type='text/javascript'>mocha.reporter(Mocha.BrowserStack);</script>\n";
+	  }else{
+	    framework_scripts['qunit'].forEach(function (script) {
+	      patch += "<script type='text/javascript' src='/_patch/" + script + "'></script>\n";
+	    });
+	  }
           patch += "</body>";
 
           file = file.replace(matcher, patch);


### PR DESCRIPTION
Added support of mocha and jasmine frameworks to browserstack-runner. Jasmine does not have a "after" functionality so added a one second poll to check if the tests are done running. For Mocha, no such mess was required. 
