### PR TITLE
Screenshot url is printed on console, after test completes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -109,6 +109,11 @@ exports.Server = function Server(bsClient, workers) {
       status += query.failed;
 
       if (worker) {
+        bsClient.takeScreenshot(worker.id,function(error,screenshot){
+          if(!error && screenshot.url){
+              console.log('[%s] Screenshot: %s', worker.string, screenshot.url);           
+          }
+
         bsClient.terminateWorker(worker.id, function () {
           if (!workers[uuid]) {
             return;
@@ -129,6 +134,7 @@ exports.Server = function Server(bsClient, workers) {
             process.exit(status);
           }
         });
+      });
       }
 
       response.end();


### PR DESCRIPTION
After worker has completed the task (and before we terminate it), Screenshot's url is displayed on console.
