### PR TITLE
allow multiple paths in test_path attribute of browserstack.json

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -62,12 +62,10 @@ console.log("Launching server..");
 var server = new Server(client, workers);
 server.listen(parseInt(serverPort, 10));
 
-function launchBrowser(browser) {
+function launchBrowser(browser,url) {
   var browserString = utils.browserString(browser);
   console.log("[%s] Launching", browserString);
 
-  var url = 'http://localhost:' + serverPort.toString() + '/';
-  url += config.test_path;
 
   var key = utils.uuid();
 
@@ -147,7 +145,15 @@ if (config.browsers && config.browsers.length > 0) {
 
           // So that all latest logs come in together
           setTimeout(function () {
-            launchBrowser(browser);
+          if(Object.prototype.toString.call(config.test_path) === '[object Array]'){
+            config.test_path.forEach(function(path){
+              var url = 'http://localhost:' + serverPort.toString() + '/' + path;
+              launchBrowser(browser,url);
+            });
+          } else {
+              var url = 'http://localhost:' + serverPort.toString() + '/' + config.test_path;
+              launchBrowser(browser,url);              
+            }
           }, 100);
         });
       } else {

--- a/lib/config.js
+++ b/lib/config.js
@@ -51,16 +51,27 @@ if (commit_id) {
   }
 });
 
+var formatPath = function(path) {
 // Convert absoulte path into relative paths.
-if (config.test_path.indexOf(pwd) === 0) {
-  config.test_path = config.test_path.slice(pwd.length + 1);
+  if (path.indexOf(pwd) === 0) {
+    path= path.slice(pwd.length + 1);
+  }
+
+  if (!fs.existsSync(path)){
+    console.error('Test path: '+ path + ' is invalid.');
+    process.exit(1);
+  }
+    return path;
 }
 
-if (!fs.existsSync(config.test_path)){
-  console.error('Test path is invalid.');
-  process.exit(1);
+if(Object.prototype.toString.call(config.test_path) === '[object Array]') {
+  config.test_path.forEach(function(path){
+    path = formatPath(path);
+  });
+} else {
+    //Backward Compatibility, if test_path is not array of path
+    config.test_path = formatPath(config.test_path);
 }
-
 for (key in config) {
   if (config.hasOwnProperty(key)) {
     exports[key] = config[key];


### PR DESCRIPTION
In browserstack.json, we can now pass, multiple test paths
    "test_path": ["js/tests/index.html","js/tests/index2.html"],
Commit ensures we are backward compatible and accept one test_path:
    "test_path": "js/tests/index.html"
- Current feedback on cli, doesn't mention which test_path is running in which browser, it just mentions the browser, I can add it in if needed.
