### PR TITLE
change download directory of jar from /tmp

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -24,7 +24,7 @@ var Tunnel = function Tunnel (key, port, tunnelIdentifier, callback, err) {
 
     console.log("Launching tunnel..");
     var subProcess = exec(tunnelCommand, function (error, stdout, stderr) {
-      console.log(stderr);
+      console.error(stderr);
       if (stdout.indexOf('Error') >= 0) {
         console.log("..Failed");
         console.log(stdout);


### PR DESCRIPTION
Downloading the jar to /tmp and running it from there sometimes raises 'Error: Invalid or corrupt jarfile /tmp/BrowserStackTunnel.jar' this error on travis.
