### PR TITLE
Support for env var driven browserstack.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ A sample configuration file:
     }
 
 
+### Enviroment variables
+
+* `BROWSERSTACK_USER`:
+BrowserStack user name.
+
+* `BROWSERSTACK_KEY`:
+BrowserStack key.
+
+* `TUNNEL_ID`:
+Identifier for the current instance of the tunnel process. In `TRAVIS` setup `TRAVIS_JOB_ID` will be the default identifier.
+
+* `BROWSERSTACK_JSON`:
+Path to the browserstack.json file. If null, `browserstack.json` in the root directory will be used.
+
+
 ### Secure Information
 
 To prevent checking in the BrowserStack `username` and `key` in your

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,8 +2,12 @@ var path = require('path'),
     fs = require('fs');
 var pwd = process.cwd();
 
+config_path = process.env.BROWSERSTACK_JSON || 'browserstack.json';
+config_path = path.resolve(path.relative(process.cwd(), config_path));
+console.log("Using config:", config_path);
+
 try {
-  var config = require(process.cwd() + '/browserstack');
+  var config = require(config_path);
 } catch (e) {
   if (e.code == 'MODULE_NOT_FOUND') {
     console.log('Configuration file `browserstack.json` is missing.');


### PR DESCRIPTION
1. BROWSERSTACK_JSON can definer the config json path
2. Updated README for environment vars
