### PR TITLE
Provide some colored output and detailed assertion logging for QUnit

### DIFF
--- a/lib/_patch/browserstack.js
+++ b/lib/_patch/browserstack.js
@@ -23,7 +23,7 @@
         if (req.readyState==4)
           cb(req.responseText);
       };
-    var data = "data=" + JSON.stringify(json)
+    var data = "data=" + encodeURIComponent(JSON.stringify(json));
     req.open("POST", url, true);
     req.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     req.setRequestHeader('X-Browser-String', BrowserStack.browser_string);

--- a/lib/_patch/qunit-plugin.js
+++ b/lib/_patch/qunit-plugin.js
@@ -39,9 +39,9 @@
 
     var error = {
       actual: details.actual,
-      expected: encodeURIComponent(details.expected),
-      message: encodeURIComponent(details.message),
-      source: encodeURIComponent(details.source),
+      expected: details.expected,
+      message: details.message,
+      source: details.source,
       testName:( details.module + ": " + details.name)
     };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,8 @@ var http = require("http"),
   qs = require("querystring"),
   utils = require("./utils"),
   config = require('../lib/config'),
-  exec = require('child_process').exec;
+  exec = require('child_process').exec,
+  chalk = require('chalk');
 
 var mimeTypes = {
   "html": "text/html",
@@ -111,6 +112,26 @@ exports.Server = function Server(bsClient, workers) {
     return JSON.parse(qs.parse(body).data.escapeSpecialChars());
   }
 
+  function formatTraceback(details) {
+    // looks like QUnit data
+    if (details.testName) {
+      var output = "'" + details.testName + "' failed";
+      if (details.message) {
+        output += ", " + details.message;
+      }
+      if (details.actual && details.expected) {
+        output += "\n" + chalk.blue("Expected: ") + details.expected +
+          "\n" + chalk.blue("  Actual: ") + details.actual;
+      }
+      if (details.source) {
+        output += "\n" + chalk.blue("  Source: ") + "";
+        output += details.source.split("\n").join("\n\t  ");
+      }
+      return output;
+    }
+    return details;
+  }
+
   handlers = {
     "_progress": function progressHandler(uri, body, request, response) {
       var uuid = request.headers['x-worker-uuid'];
@@ -119,13 +140,13 @@ exports.Server = function Server(bsClient, workers) {
       try {
         query = parseBody(body);
       } catch(e) {
-        console.log("[%s] Exception in parsing QUnit log", worker.string)
-        console.log("[%s] Log: " + qs.parse(body).data, worker.string)
+        console.log("[%s] Exception in parsing log", worker.string);
+        console.log("[%s] Log: " + qs.parse(body).data, worker.string);
       }
 
       if (query.tracebacks) {
         query.tracebacks.forEach(function(traceback) {
-          console.log("[%s] Error:", worker.string, traceback);
+          console.log(chalk.red("[%s] Error:"), worker.string, formatTraceback(traceback));
         });
       }
       response.end();
@@ -148,8 +169,8 @@ exports.Server = function Server(bsClient, workers) {
             console.log(traceback);
           });
         }
-
-        console.log("[%s] Completed in %d milliseconds. %d of %d passed, %d failed.", request.headers['x-browser-string'], query.runtime, query.passed, query.total, query.failed);
+        var color = query.failed ? "red" : "green";
+        console.log(chalk[color]("[%s] Completed in %d milliseconds. %d of %d passed, %d failed."), request.headers['x-browser-string'], query.runtime, query.passed, query.total, query.failed);
         status += query.failed;
       }
 
@@ -170,7 +191,8 @@ exports.Server = function Server(bsClient, workers) {
             delete workers[uuid];
 
             if (utils.objectSize(workers) === 0) {
-              console.log("All tests done, failures: %d.", status);
+              var color = status > 0 ? "red" : "green";
+              console.log(chalk[color]("All tests done, failures: %d."), status);
 
               if (status > 0) {
                 status = 1;


### PR DESCRIPTION
This partly addresses #41

It includes `chalk` for colouring output, making the main passed/failed messages green or red, along with better formatted output for failed QUnit assertions. As mentioned in #36, its currently difficult to test with other frameworks, so I haven't addressed anything else.

As an example, for a failing assertion, output looks like this, running against Firefox 17:

![xxx](http://bassistance.de/i/b98f90.png)

Same setup, now everything passes:

![xxx](http://bassistance.de/i/8cf823.png)
