### PR TITLE
failed test support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 tmp
 node_modules
+lib/BrowserStackLocal
 browserstack.json
 browserstack-runner.pid
+browserstack-failed.json

--- a/lib/failed.js
+++ b/lib/failed.js
@@ -1,0 +1,38 @@
+var path = require('path'),
+  fs = require('fs');
+var pwd = process.cwd();
+
+failed_path = path.resolve(path.relative(process.cwd(), 'browserstack-failed.json'));
+
+try {
+  var failed = require(failed_path);
+} catch (e) {
+}
+
+exports['browsers'] = [];
+
+if(failed){
+  console.log("Launching tests on previously failed browsers only:", failed_path);
+
+  exports['browsers'] = failed;
+}
+
+var failed = [];
+var hasFailed = false;
+
+exports['cleanUp'] = function(browser){
+  if(!hasFailed){
+    fs.unlink(failed_path);
+  }
+};
+
+exports['add'] = function(browser){
+  delete browser.url;
+
+  hasFailed = true;
+
+  failed.push(browser);
+
+  var json = JSON.stringify(failed, null, 4);
+  fs.writeFileSync(failed_path, json, 'utf-8')
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,7 @@ var http = require("http"),
   qs = require("querystring"),
   utils = require("./utils"),
   config = require('../lib/config'),
+  failed = require('../lib/failed'),
   exec = require('child_process').exec,
   chalk = require('chalk');
 
@@ -172,6 +173,10 @@ exports.Server = function Server(bsClient, workers) {
         var color = query.failed ? "red" : "green";
         console.log(chalk[color]("[%s] Completed in %d milliseconds. %d of %d passed, %d failed."), request.headers['x-browser-string'], query.runtime, query.passed, query.total, query.failed);
         status += query.failed;
+
+        if(query.failed){
+          failed.add(worker.config);
+        }
       }
 
       if (worker) {


### PR DESCRIPTION
Add feature where browsers that fail are written to browserstack-failed.json. When the user tries to re-run the tests, it will read the array from that file and execute tests vs. starting all the way over. It could be enhanced to ask user at start if they want to use it, as well as determining which of the test_paths failed during execution.