### PR TITLE
support fallback to local server, related to #57

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -10,6 +10,12 @@ var Log = require('./logger'),
   exec = require('child_process').exec,
   chalk = require('chalk');
 
+  var proxy = null;
+
+  if(config.proxy){
+    proxy = new require('http-proxy').createProxyServer({});
+  }
+
 var mimeTypes = {
   "html": "text/html",
   "json": "text/json",
@@ -227,6 +233,12 @@ exports.Server = function Server(bsClient, workers) {
     var filename;
 
     var body = '';
+
+    if(proxy && method == 'proxy'){
+      proxy.proxyRequest(request, response, {target:config.proxy});
+
+      return;
+    }
 
     request.on('data', function(data) {
       body += data;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "browserstack": "1.0.1",
-    "chalk": "0.4.0"
+    "chalk": "0.4.0",
+    "http-proxy": "1.0.3"
   },
   "licenses": [
     {


### PR DESCRIPTION
want to use local stub server when running tests, this allows user to place {proxy:"http://localhost:port"} in browserstack.json. any urls that begin with /proxy will route through the proxy.