### PR TITLE
Server: Append injected scripts to body instead of head

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -92,7 +92,7 @@ exports.Server = function Server(bsClient, workers) {
           pathMatches = (filePath == config.test_path);
         }
         if (pathMatches && mimeType === 'text/html') {
-          var matcher = /(.*)<\/head>/;
+          var matcher = /(.*)<\/body>/;
           var patch = "$1";
           scripts.forEach(function(script) {
             patch += "<script type='text/javascript' src='/_patch/" + script + "'></script>\n";
@@ -118,7 +118,7 @@ exports.Server = function Server(bsClient, workers) {
               patch += "<script type='text/javascript' src='/_patch/" + script + "'></script>\n";
             });
           }
-          patch += "</head>";
+          patch += "</body>";
 
           file = file.replace(matcher, patch);
         }


### PR DESCRIPTION
Any setup that loads QUnit in the body instead of head will timeout out otherwise.

I ran into this while [integrating browserstack-runner with Globalize](https://github.com/jquery/globalize/issues/235). The unit testsuite there has a different setup which currently causes a timeout, even though the tests pass just fine.

I briefly looked at the `tests` folder to see if I can add or modify something there. Some pointers would be useful there. Feel free to include the Globalize test suite there, that would be a good testcase for QUnit+requirejs.
