### PR TITLE
allow test paths to have querystrings

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -28,6 +28,37 @@ function getTestBrowserInfo(worker) {
   return info;
 }
 
+// ECMASCript 6 Polyfill
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    enumerable: false,
+	configurable: true,
+	writable: true,
+	value: function(predicate) {
+	  if (this == null) {
+	    throw new TypeError('Array.prototype.find called on null or undefined');
+	  }
+	  if (typeof predicate !== 'function') {
+	    throw new TypeError('predicate must be a function');
+	  }
+	  var list = Object(this);
+	  var length = list.length >>> 0;
+	  var thisArg = arguments[1];
+	  var value;
+
+	  for (var i = 0; i < length; i++) {
+	    if (i in list) {
+	      value = list[i];
+		  if (predicate.call(thisArg, value, i, list)) {
+		    return value;
+		  }
+		}
+	  }
+	  return undefined;
+	}
+  });
+}
 
 exports.Server = function Server(bsClient, workers) {
 
@@ -86,11 +117,14 @@ exports.Server = function Server(bsClient, workers) {
         var filePath = path.relative(process.cwd(), filename);
         var pathMatches;
 
-        if (typeof config.test_path === 'object') {
-          pathMatches = (config.test_path.indexOf(filePath) != -1);
-        } else {
-          pathMatches = (filePath == config.test_path);
-        }
+		if (typeof config.test_path === 'object') {
+		  pathMatches = config.test_path.find(function (path){
+		    return path.indexOf(filePath) !== -1;
+		  });
+		} else {
+	      pathMatches = (config.test_path.indexOf(filePath) !== -1);
+		}
+
         if (pathMatches && mimeType === 'text/html') {
           var framework = config['test_framework'];
           var tag_name = (framework === "mocha") ? "head" : "body";


### PR DESCRIPTION
Currently if you provide a test path with a querystring, the test hangs on the browserstack side and eventually times out.  This is caused by the code that adds the test suite specific patch libraries.  A querystring prevents the current pattern matching code from detecting the html test file.  The test suite specific patch library is not added to the test html page.  This pull request fixes the pattern matching code to properly detect the test html file.