### PR TITLE
Reuse worker

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,7 +32,6 @@ var Log = require('../lib/logger'),
     timeout,
     activityTimeout,
     workers = {},
-    browserToWorker = {},
     workerKeys = {},
     logLevel,
     tunnelingAgent,
@@ -105,7 +104,7 @@ function cleanUpAndExit(signal, status) {
 
 function getTestBrowserInfo(browserString, path) {
   var info = browserString;
-  if(config.multipleTest) {
+  if (config.multipleTest) {
     info += ", " + path;
   }
   return info;
@@ -146,7 +145,7 @@ function launchBrowser(browser, path) {
   }
 
   timeout = parseInt(config.timeout);
-  if(! isNaN(timeout)) {
+  if (!isNaN(timeout)) {
     browser.timeout = timeout;
   } else {
     timeout = 300;
@@ -167,6 +166,7 @@ function launchBrowser(browser, path) {
     worker.config = browser;
     worker.string = browserString;
     worker.test_path = path;
+    worker.path_index = 0;
     workers[key] = worker;
     workerKeys[worker.id] = {key: key, marked: false};
   });
@@ -175,15 +175,9 @@ function launchBrowser(browser, path) {
 
 function launchBrowsers(config, browser) {
   setTimeout(function () {
-    if(Object.prototype.toString.call(config.test_path) === '[object Array]'){
+    if (Object.prototype.toString.call(config.test_path) === '[object Array]'){
       config.multipleTest = config.test_path.length > 1? true : false;
-      if(config.reuseWorker) {
-        launchBrowser(browser, config.test_path[0]);
-      } else {
-        config.test_path.forEach(function(path){
-          launchBrowser(browser, path);
-        });
-      }
+      launchBrowser(browser, config.test_path[0]);
     } else {
       config.multipleTest = false;
       launchBrowser(browser, config.test_path);
@@ -282,8 +276,8 @@ function runTests() {
       launchServer();
       tunnel = new Tunnel(config.key, serverPort, config.tunnelIdentifier, function () {
         statusPoller.start();
-        var total_workers = config.browsers.length * (Object.prototype.toString.call(config.test_path) === '[object Array]' ? config.test_path.length : 1);
-        logger.info("Launching " + total_workers + " workers");
+        var total_runs = config.browsers.length * (Object.prototype.toString.call(config.test_path) === '[object Array]' ? config.test_path.length : 1);
+        logger.info("Launching " + config.browsers.length + " worker(s) for " + total_runs + " run(s).");
         browsers.forEach(function(browser) {
           if (browser.browser_version === "latest") {
             logger.debug("[%s] Finding version.", utils.browserString(browser));

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,6 +49,8 @@ var commit_id = process.env.TRAVIS_COMMIT;
 
 if (commit_id) {
   config.build = "Commit-" + commit_id.slice(0, commit_id.length / 2);
+} {
+  config.build = "Local run, " + new Date().toISOString();
 }
 
 ['username', 'key', 'test_path', 'browsers'].forEach(function(param) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -158,11 +158,12 @@ exports.Server = function Server(bsClient, workers) {
   }
 
   function checkAndTerminateWorker(worker, callback) {
-    if(config.reuseWorker && config.multipleTest) {
-      var next_path = getNextTestPath(worker.test_path);
+    var next_path = getNextTestPath(worker);
+    if (next_path) {
       var new_url = 'http://localhost:' + 8888 + '/' + next_path
-        + "_worker_key=" + worker._worker_key + "&_browser_string=" + getTestBrowserInfo(worker) ;
-      bsClient.postNewUrl(worker.id, {url: new_url}, function() {
+        + "?_worker_key=" + worker._worker_key + "&_browser_string=" + getTestBrowserInfo(worker) ;
+      worker.test_path = next_path;
+      bsClient.changeUrl(worker.id, {url: new_url}, function() {
         callback(true);
       });
     } else {
@@ -170,14 +171,11 @@ exports.Server = function Server(bsClient, workers) {
     }
   };
 
-  function getNextTestPath(test_path) {
-    // Someday I'll die for codes like these
-    for(var i = 0; i < config.test_path.length; i++) {
-      if(config.test_path[i] == test_path) {
-        return config.test_path[ i + 1 ];
-      }
+  function getNextTestPath(worker) {
+    if (!config.multipleTest) {
+      return null;
     }
-
+    return config.test_path[ ++worker.path_index ];
   }
 
   handlers = {
@@ -234,7 +232,7 @@ exports.Server = function Server(bsClient, workers) {
               return;
             }
 
-            if(reusedWorker) {
+            if (reusedWorker) {
               logger.debug('[%s] Reused', getTestBrowserInfo(worker));
               return;
             }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/browserstack/browserstack-runner.git"
   },
   "dependencies": {
-    "browserstack": "1.0.1",
+    "browserstack": "1.1.0",
     "chalk": "0.4.0",
     "tunnel": "0.0.3"
   },


### PR DESCRIPTION
Fixes #73 

Been testing this with the testsuites in QUnit itself and jQuery UI. It launches just one worker per browser and reuses them as expected.

In addition to fixing various bugs in @dhimil's implementation, I've also made a useful improvement, by always setting `config.build`. The format is based on what Karma uses for local runs.

@dhimil's commit introduced a `reuseWorker` configuration option. I didn't see the point of making this configurable, so removed the option. If there's more than one test page, workers are automatically reused.
