### PR TITLE
Server: Fix query string concatenation

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -160,10 +160,15 @@ exports.Server = function Server(bsClient, workers) {
   function checkAndTerminateWorker(worker, callback) {
     var next_path = getNextTestPath(worker);
     if (next_path) {
-      var new_url = 'http://localhost:' + 8888 + '/' + next_path
-        + "?_worker_key=" + worker._worker_key + "&_browser_string=" + getTestBrowserInfo(worker) ;
+      var url = 'http://localhost:' + 8888 + '/' + next_path;
+      if (url.indexOf('?') > 0) {
+        url += '&';
+      } else {
+        url += '?';
+      }
+      url += "_worker_key=" + worker._worker_key + "&_browser_string=" + getTestBrowserInfo(worker) ;
       worker.test_path = next_path;
-      bsClient.changeUrl(worker.id, {url: new_url}, function() {
+      bsClient.changeUrl(worker.id, {url: url}, function() {
         callback(true);
       });
     } else {


### PR DESCRIPTION
If the path already contains the question mark starting the query string, use an ampersand instead.

Noticed the incorrect URLs while testing a page that already had a query string.
