### PR TITLE
Fix jasmine patch

### DIFF
--- a/lib/_patch/jasmine-plugin.js
+++ b/lib/_patch/jasmine-plugin.js
@@ -1,45 +1,45 @@
 (function(){
   function countSpecs(suite, results){
-    for(var i = 0; i < suite.specs.length; ++i) {
-      if(suite.specs[i].passed){
-	    results.passed++;
+    for (var i = 0; i < suite.specs.length; ++i) {
+      if (suite.specs[i].passed){
+        results.passed++;
       } else {
         results.tracebacks.push(suite.specs[i].description);
         results.failed++;
       }
     }
 
-    for(var i = 0; i < suite.suites.length; ++i) {
-      if(suite.suites[i]) {
+    for (var i = 0; i < suite.suites.length; ++i) {
+      if (suite.suites[i]) {
         results = countSpecs(suite.suites[i], results);
       }
     }
-    
-    return(results);
+
+    return results;
   }
 
-  var checker = setInterval(function(){
-    if(!jasmine.running){
+  var checker = setInterval(function() {
+    if (!jasmine.running) {
       var results = {};
       var report = jasmine.getJSReport();
       results.runtime = report.durationSec * 1000;
-      results.total=0;
-      results.passed=0;
-      results.failed=0;
-      results.tracebacks=[];
+      results.total = 0;
+      results.passed = 0;
+      results.failed = 0;
+      results.tracebacks = [];
 
-      for(var i = 0; i < report.suites.length; ++i) {
-    	  if(report.suites[i]) {
-    		  results = countSpecs(report.suites[i], results);
-    	  }
+      for (var i = 0; i < report.suites.length; ++i) {
+        if (report.suites[i]) {
+          results = countSpecs(report.suites[i], results);
+        }
       }
-      
+
       results.total = results.passed + results.failed;
 
       results.url = window.location.pathname;
       BrowserStack.post("/_report", results, function(){});
+      clearInterval(checker);
     }
-    clearInterval(checker);
   }, 1000);
 })();
 

--- a/lib/_patch/jasmine-plugin.js
+++ b/lib/_patch/jasmine-plugin.js
@@ -1,33 +1,39 @@
 (function(){
   function countSpecs(suite, results){
-    suite.specs.forEach(function(s){
-      if(s.passed){
-	results.passed++;
-      }else{
-	results.tracebacks.push(s.description);
-	results.failed++;
+    for(var i = 0; i < suite.specs.length; ++i) {
+      if(suite.specs[i].passed){
+	    results.passed++;
+      } else {
+        results.tracebacks.push(suite.specs[i].description);
+        results.failed++;
       }
-    });
-    suite.suites.forEach(function(s){
-      results = countSpecs(s, results);
-    });
+    }
+
+    for(var i = 0; i < suite.suites.length; ++i) {
+      if(suite.suites[i]) {
+        results = countSpecs(suite.suites[i], results);
+      }
+    }
+    
     return(results);
   }
 
   var checker = setInterval(function(){
     if(!jasmine.running){
-      var results = {}
-      var report = jasmine.getJSReport()
-      var errors = [];
+      var results = {};
+      var report = jasmine.getJSReport();
       results.runtime = report.durationSec * 1000;
       results.total=0;
       results.passed=0;
       results.failed=0;
       results.tracebacks=[];
 
-      jasmine.getJSReport().suites.forEach(function(suite){
-	results = countSpecs(suite, results);
-      });
+      for(var i = 0; i < report.suites.length; ++i) {
+    	  if(report.suites[i]) {
+    		  results = countSpecs(report.suites[i], results);
+    	  }
+      }
+      
       results.total = results.passed + results.failed;
 
       results.url = window.location.pathname;


### PR DESCRIPTION
This takes the changes from #88, squashes them into one commit, then formats the code properly (add some spacing, use consistent indentation) and fixes something I consider a bug: It moves the `clearInterval` into the `running` check, where it makes much more sense. From the commit message:

> It makes no sense to clear the interval while Jasmine is still running,
potentially never reporting results when the suite didn't finish after
the first interval ran.

I've ran `ruby tests/test.rb` to verify it works.