### PR TITLE
Windows fixes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -120,7 +120,7 @@ function launchServer() {
 }
 
 function launchBrowser(browser, path) {
-  var url = 'http://localhost:' + serverPort.toString() + '/' + path.replace(/\\/gi, '/');
+  var url = 'http://localhost:' + serverPort.toString() + '/' + path.replace(/\\/g, '/');
   var browserString = utils.browserString(browser);
   logger.debug('[%s] Launching', getTestBrowserInfo(browserString, path));
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -120,7 +120,7 @@ function launchServer() {
 }
 
 function launchBrowser(browser, path) {
-  var url = 'http://localhost:' + serverPort.toString() + '/' + path;
+  var url = 'http://localhost:' + serverPort.toString() + '/' + path.replace(/\\/gi, '/');
   var browserString = utils.browserString(browser);
   logger.debug('[%s] Launching', getTestBrowserInfo(browserString, path));
 
@@ -224,7 +224,7 @@ var statusPoller = {
                     config.status = 1;
                   }
 
-                  process.kill(process.pid, 'SIGTERM');
+                  process.exit('SIGTERM');
                 }
               }
             }, activityTimeout * 1000);
@@ -245,7 +245,7 @@ var statusPoller = {
                     config.status = 1;
                   }
 
-                  process.kill(process.pid, 'SIGTERM');
+                  process.exit('SIGTERM');
                 }
               }
             }, (activityTimeout * 1000));
@@ -308,11 +308,8 @@ try {
   runTests();
   var pid_file = process.cwd() + '/browserstack-run.pid';
   fs.writeFileSync(pid_file, process.pid, 'utf-8');
-  process.on('SIGINT', function() {
-    cleanUpAndExit('SIGINT', 1);
-  });
-  process.on('SIGTERM', function() {
-    cleanUpAndExit('SIGTERM', config.status);
+  process.on('exit', function(signal){
+    cleanUpAndExit(signal, config.status);
   });
 } catch (e) {
   console.log(e);

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,6 +61,10 @@ if (commit_id) {
 });
 
 var formatPath = function(path) {
+  if(/^win/.test(process.platform)){
+    path = path.replace(/\//gi, '\\');
+  }
+  
   if (path.indexOf(pwd) === 0) {
     path = path.slice(pwd.length + 1);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -61,8 +61,8 @@ if (commit_id) {
 });
 
 var formatPath = function(path) {
-  if(/^win/.test(process.platform)){
-    path = path.replace(/\//gi, '\\');
+  if (/^win/.test(process.platform)) {
+    path = path.replace(/\//g, '\\');
   }
   
   if (path.indexOf(pwd) === 0) {

--- a/lib/local.js
+++ b/lib/local.js
@@ -59,14 +59,14 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
     that.process = subProcess;
   }
 
-  function getTunnelOptions(key, uniqueIdentifier){
+  function getTunnelOptions(key, uniqueIdentifier) {
     var options = [key];
     
     if (config.debug) {
       options.push('-v');
     }
   
-    if(!uniqueIdentifier){
+    if (!uniqueIdentifier) {
       options.push('-force');
       options.push('-onlyAutomate');
     } else {
@@ -75,11 +75,11 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
     
     var proxy = config.proxy;
     
-    if(proxy){
+    if (proxy) {
       options.push('-proxyHost ' + proxy.host);
       options.push('-proxyPort ' + proxy.port);
           
-      if(proxy.username && proxy.password){
+      if (proxy.username && proxy.password) {
         options.push('-proxyUser ' + proxy.username);
         options.push('-proxyPass ' + proxy.password);
       }

--- a/lib/local.js
+++ b/lib/local.js
@@ -1,10 +1,10 @@
 var Log = require('./logger'),
   logger = new Log(global.logLevel),
-  exec = require('child_process').exec,
+  exec = require('child_process').execFile,
   fs = require('fs'),
   http = require('http'),
   windows = ((process.platform.match(/win32/) || process.platform.match(/win64/)) !== null),
-  localBinary = process.cwd() + (windows ? '/BrowserStackTunnel.jar' : '/BrowserStackLocal'),
+  localBinary = process.cwd() + '/BrowserStackLocal' + (windows ? '.exe' : ''),
   utils = require('./utils'),
   config = require('./config');
 
@@ -12,29 +12,21 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
   var that = {};
 
   function tunnelLauncher() {
-    var tunnelCommand = (windows ? 'java -jar ' : '') + localBinary + ' ';
-    if (config.debug) {
-      tunnelCommand += ' -v ';
-    }
-    tunnelCommand += key + ' ';
-    tunnelCommand += 'localhost' + ',';
-    tunnelCommand += port.toString() + ',';
-    tunnelCommand += '0';
-    tunnelCommand += (typeof uniqueIdentifier === 'undefined') ? ' -force -onlyAutomate' : ' -tunnelIdentifier ' + uniqueIdentifier;
-    tunnelCommand += checkAndAddProxy();
+    var tunnelOptions = getTunnelOptions(key, uniqueIdentifier);
 
     if (typeof callback !== 'function') {
       callback = function(){};
     }
 
     logger.debug('[%s] Launching tunnel', new Date());
-    var subProcess = exec(tunnelCommand, function(error, stdout, stderr) {
+
+    var subProcess = exec(localBinary, tunnelOptions, function(error, stdout, stderr) {
       logger.debug(stderr);
       logger.debug(error);
       if (stdout.indexOf('Error') >= 0 || error) {
         logger.debug('[%s] Tunnel launching failed', new Date());
         logger.debug(stdout);
-        process.kill(process.pid, 'SIGINT');
+        process.exit('SIGINT');
       }
     });
 
@@ -67,19 +59,33 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
     that.process = subProcess;
   }
 
-  function checkAndAddProxy() {
+  function getTunnelOptions(key, uniqueIdentifier){
+    var options = [key];
+    
+    if (config.debug) {
+      options.push('-v');
+    }
+  
+    if(!uniqueIdentifier){
+      options.push('-force');
+      options.push('-onlyAutomate');
+    } else {
+      options.push('-localIdentifier ' + uniqueIdentifier);
+    }
+    
     var proxy = config.proxy;
-    if (typeof proxy === 'undefined') {
-      return '';
+    
+    if(proxy){
+      options.push('-proxyHost ' + proxy.host);
+      options.push('-proxyPort ' + proxy.port);
+          
+      if(proxy.username && proxy.password){
+        options.push('-proxyUser ' + proxy.username);
+        options.push('-proxyPass ' + proxy.password);
+      }
     }
-    var proxyCommand = '';
-    proxyCommand += ' -proxyHost ' + proxy.host;
-    proxyCommand += ' -proxyPort ' + proxy.port;
-    if(typeof proxy.username !== 'undefined'){
-      proxyCommand += ' -proxyUser ' + proxy.username;
-      proxyCommand += ' -proxyPass ' + proxy.password;
-    }
-    return proxyCommand;
+    
+    return options;
   }
 
   fs.exists(localBinary, function(exists) {
@@ -87,10 +93,10 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
       tunnelLauncher();
       return;
     }
-    logger.debug('Downloading BrowserStack Local to `%s`', localBinary);
+    logger.debug('Downloading BrowserStack Local to "%s"', localBinary);
 
     var file = fs.createWriteStream(localBinary);
-    http.get(windows ? 'http://www.browserstack.com/BrowserStackTunnel.jar' : ('http://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal-' + process.platform + '-' + process.arch),
+    http.get((windows ? 'http://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal.exe' : ('http://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal-' + process.platform + '-' + process.arch)),
     function(response) {
       response.pipe(file);
 
@@ -101,7 +107,7 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
         }, 100);
       }).on('error', function(e) {
         logger.info('Got error while downloading binary: ' + e.message);
-        process.kill(process.pid, 'SIGINT');
+        process.exit('SIGINT');
       });
     });
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -254,7 +254,7 @@ exports.Server = function Server(bsClient, workers) {
               config.status = 1;
             }
 
-            process.kill(process.pid, 'SIGTERM');
+            process.exit('SIGTERM');
           }
         });
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,7 +57,7 @@ var alertBrowserStack = function alertBrowserStack(subject, content, params, fn)
     if (typeof params === 'function') {
     } else {
       fn = function() {
-        process.kill(process.pid, 'SIGINT');
+        process.exit('SIGINT');
       };
     }
   }


### PR DESCRIPTION
Changed to BrowserStackLocal.exe instead of the jar-file.
The tunnel process is now killed when the tests are complete.
Before when using the jar-file the tunnel processes still were alive in the background after the test were completed. Which created problem the next time you ran the tests, your worker then never received the "Acknowledge" state,

Added path fix for Windows, it now works with "/" on Windows in the "test_path" config.

Fixed the Process signals to work on Windows, before you never got to the method "cleanUpAndExit" in cli.js because of how Process.kill works on Windows. It now runs "cleanUpAndExit" before exiting the process as expected.