### PR TITLE
Ignore tests folder when publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.editorconfig
+.jshintrc
+tests


### PR DESCRIPTION
Shouldn't include all the external repos when publishing. Also ignoring two dot files that aren't needed outside of the repo.

I haven't actually tests this, since that requires publishing.