### PR TITLE
Allow to add custom build string

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To run browser tests on BrowserStack infrastructure, you need to create a `brows
  * `test_framework`: Specify test framework which will run the tests. Currently supporting qunit, jasmine, jasmine2 and mocha.
  * `timeout`: Specify worker timeout with BrowserStack.
  * `browsers`: A list of browsers on which tests are to be run. Find a [list of all supported browsers and platforms on browerstack.com](http://www.browserstack.com/list-of-browsers-and-platforms?product=live).
+ * `build`: A string to identify your test run in Browserstack.  In `TRAVIS` setup `TRAVIS_COMMIT` will be the default identifier.
  * `proxy`: Specify a proxy to use for the local tunnel. Object with `host`, `port`, `username` and `password` properties.
 
 A sample configuration file:

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,10 +47,8 @@ if (!config.project) {
 
 var commit_id = process.env.TRAVIS_COMMIT;
 
-if (commit_id) {
-  config.build = 'Commit-' + commit_id.slice(0, commit_id.length / 2);
-} {
-  config.build = 'Local run, ' + new Date().toISOString();
+if(!config.build) {
+  config.build = commit_id ? 'Commit-' + commit_id.slice(0, commit_id.length / 2) : 'Local run, ' + new Date().toISOString();
 }
 
 ['username', 'key', 'test_path', 'browsers'].forEach(function(param) {


### PR DESCRIPTION
Currently the `build` property in `browserstack.json` is not working correctly. A bug introduced [here](https://github.com/browserstack/browserstack-runner/commit/8f936a400bfc276fd5c20ed34042afb87fb3f1ad#diff-f7bf2b665273dfa66ffa4ad7c0a52bb9R52) means that the `config.build` is always set to the `Local run` string. I'm presuming it should be an `else` statement there?

I've also changed it so you can have a custom build string set in your `browserstack.json`. If there is a build string set it won't set to it the 'Commit-` or 'Local run,' string but will use that instead

I've also updated the README with information about updating the `build` string.