### PR TITLE
Support IE8 in Mocha tests

### DIFF
--- a/lib/_patch/mocha-plugin.js
+++ b/lib/_patch/mocha-plugin.js
@@ -54,7 +54,7 @@
 
     runner.on('end', function() {
       results = {};
-      results.runtime = Date.now() - start;
+      results.runtime = (new Date).getTime() - start;
       results.total = passes + failures;
       results.passed = passes;
       results.failed = failures;


### PR DESCRIPTION
Replaced Date.now() with (new Date).getTime() because Date.now() is not supported until IE9.