### PR TITLE
Local: Revert writing tunnel file into working dir, document npm fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ You can also install locally and run the local binary:
     npm install browserstack-runner
     node_modules/.bin/browserstack-runner
 
+If you're getting an error `EACCES open ... BrowserStackLocal`, configure npm to install modules using something other than the default "nobody" user:
+
+    npm -g config set user [user]
+
+Where `[user]` is replaced with a local user with enough permissions.
+
 ## Configuration
 
 To run browser tests on BrowserStack infrastructure, you need to create a `browserstack.json` file in project's root directory (the directory from which tests are run), by running this command:

--- a/lib/local.js
+++ b/lib/local.js
@@ -4,7 +4,7 @@ var Log = require('./logger'),
   fs = require('fs'),
   http = require('http'),
   windows = ((process.platform.match(/win32/) || process.platform.match(/win64/)) !== null),
-  localBinary = process.cwd() + '/BrowserStackLocal' + (windows ? '.exe' : ''),
+  localBinary = __dirname + '/BrowserStackLocal' + (windows ? '.exe' : ''),
   utils = require('./utils'),
   config = require('./config');
 
@@ -61,30 +61,30 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
 
   function getTunnelOptions(key, uniqueIdentifier) {
     var options = [key];
-    
+
     if (config.debug) {
       options.push('-v');
     }
-  
+
     if (!uniqueIdentifier) {
       options.push('-force');
       options.push('-onlyAutomate');
     } else {
       options.push('-localIdentifier ' + uniqueIdentifier);
     }
-    
+
     var proxy = config.proxy;
-    
+
     if (proxy) {
       options.push('-proxyHost ' + proxy.host);
       options.push('-proxyPort ' + proxy.port);
-          
+
       if (proxy.username && proxy.password) {
         options.push('-proxyUser ' + proxy.username);
         options.push('-proxyPass ' + proxy.password);
       }
     }
-    
+
     return options;
   }
 


### PR DESCRIPTION
Revert "On linux, EACCES open ... BrowserStackLocal error. Fixes #91"

This reverts commit c27a2adb88c02c72842dadb2b6fe4cce17137e28

Documents how to avoid the issue described in #91 by configuring npm
properly.

Ref #91
Fixes #105