### PR TITLE
Prevent fatal error when it gets a 403 Error

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -193,6 +193,10 @@ var statusPoller = {
   start: function() {
     statusPoller.poller = setInterval(function () {
       client.getWorkers(function (err, _workers) {
+        if (!_workers) {
+          logger.info(chalk.red('Error found: ' + err));
+          return;
+        }
         _workers.filter(function(currentValue) {
           return currentValue.status === 'running' && workerKeys[currentValue.id] && !workerKeys[currentValue.id].marked;
         }).forEach(function(_worker) {


### PR DESCRIPTION
This commit introduces a handler for `client.getWorkers` when it receives an error argument.

This way it won't break JS from running, but instead will just report the error and continue.

This is not the best way to fix this problem, but this will prevent false statements on CI runs, creating warnings rather than fatal errros.

There's more to be done until it's reasonable, but at least it reports more specific bugs.

And it seems that it's still timing out.