### PR TITLE
Retry opening URL if worker-browser fails to send request within ackTimeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -20,14 +20,6 @@ var mimeTypes = {
   'css': 'text/css'
 };
 
-function getTestBrowserInfo(worker) {
-  var info = worker.string;
-  if(config.multipleTest) {
-    info += ', ' + worker.test_path;
-  }
-  return info;
-}
-
 
 exports.Server = function Server(bsClient, workers) {
 
@@ -37,8 +29,7 @@ exports.Server = function Server(bsClient, workers) {
 
     if (query._worker_key && workers[query._worker_key]) {
       var worker = workers[query._worker_key];
-      worker.acknowledged = true;
-      logger.debug('[%s] Acknowledged', getTestBrowserInfo(worker));
+      worker.markAckd();
     }
 
     var getReporterPatch = function (mimeType) {
@@ -187,18 +178,14 @@ exports.Server = function Server(bsClient, workers) {
   function checkAndTerminateWorker(worker, callback) {
     var next_path = getNextTestPath(worker);
     if (next_path) {
-      var url = 'http://localhost:' + 8888 + '/' + next_path;
-      if (url.indexOf('?') > 0) {
-        url += '&';
-      } else {
-        url += '?';
-      }
-      url += '_worker_key=' + worker._worker_key + '&_browser_string=' + getTestBrowserInfo(worker) ;
+      var url = worker.buildUrl(next_path);
       worker.test_path = next_path;
       worker.config.url = next_path;
-      bsClient.changeUrl(worker.id, {url: url}, function() {
+
+      bsClient.changeUrl(worker.id, { url: url }, function () {
         callback(true);
       });
+
     } else {
       bsClient.terminateWorker(worker.id, callback);
     }
@@ -225,7 +212,7 @@ exports.Server = function Server(bsClient, workers) {
 
       if (query.tracebacks) {
         query.tracebacks.forEach(function(traceback) {
-          logger.info('[%s] ' + chalk.red('Error:'), getTestBrowserInfo(worker), formatTraceback(traceback));
+          logger.info('[%s] ' + chalk.red('Error:'), worker.getTestBrowserInfo(), formatTraceback(traceback));
         });
       }
       response.end();
@@ -244,19 +231,19 @@ exports.Server = function Server(bsClient, workers) {
         logger.info('[%s] Null response from remote Browser', request.headers['x-browser-string']);
       } else {
         if (query.tracebacks && query.tracebacks.length > 0) {
-          logger.info('[%s] ' + chalk['red']('Tracebacks:'), getTestBrowserInfo(worker));
+          logger.info('[%s] ' + chalk['red']('Tracebacks:'), worker.getTestBrowserInfo());
           query.tracebacks.forEach(function(traceback) {
             logger.info(traceback);
           });
         }
         var color = query.failed ? 'red' : 'green';
-        logger.info('[%s] ' + chalk[color](query.failed ? 'Failed:' : 'Passed:') + ' %d tests, %d passed, %d failed; ran for %dms', getTestBrowserInfo(worker), query.total, query.passed, query.failed, query.runtime);
+        logger.info('[%s] ' + chalk[color](query.failed ? 'Failed:' : 'Passed:') + ' %d tests, %d passed, %d failed; ran for %dms', worker.getTestBrowserInfo(), query.total, query.passed, query.failed, query.runtime);
         config.status += query.failed;
       }
 
       bsClient.takeScreenshot(worker.id, function(error, screenshot) {
         if (!error && screenshot.url && query && query.failed) {
-          logger.info('[%s] ' + chalk.yellow('Screenshot:') + ' %s', getTestBrowserInfo(worker), screenshot.url);
+          logger.info('[%s] ' + chalk.yellow('Screenshot:') + ' %s', worker.getTestBrowserInfo(), screenshot.url);
         }
 
         checkAndTerminateWorker(worker, function(reusedWorker) {
@@ -265,12 +252,15 @@ exports.Server = function Server(bsClient, workers) {
           }
 
           if (reusedWorker) {
-            logger.debug('[%s] Reused', getTestBrowserInfo(worker));
+            logger.debug('[%s] Reused', worker.getTestBrowserInfo());
+            worker.resetAck();
+            worker.awaitAck();
             return;
           }
 
-          logger.debug('[%s] Terminated', getTestBrowserInfo(worker));
+          logger.debug('[%s] Terminated', worker.getTestBrowserInfo());
 
+          clearTimeout(workers[uuid].ackTimeout);
           clearTimeout(workers[uuid].activityTimeout);
           clearTimeout(workers[uuid].testActivityTimeout);
           delete workers[uuid];


### PR DESCRIPTION
* Attempts to set the URL one additional time just in case a newly created (or reused) worker fails to set it
* Similar in approach to the other PR on this issue
* Incorporates changes requested and minor code cleanup

Run with `--verbose` to see ack check and re-request behaviour.
