### PR TITLE
Don't assume qunit is the default test framework

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -78,7 +78,7 @@ exports.Server = function Server(bsClient, workers) {
             patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
           });
           patch += '<script type="text/javascript">mocha.reporter(Mocha.BrowserStack);</script>\n';
-        } else {
+        } else if (framework === 'qunit') {
           framework_scripts['qunit'].forEach(function(script) {
             patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
           });


### PR DESCRIPTION
I'm testing using [tape](https://github.com/substack/tape), and am calling `BrowserStack.post` myself.

I am not supplying in any string for the `test_framework` property in browserstack.json.

When the qunit patch is included, errors occur in the console log.

This patch fixes the error, so that qunit code is only injected if the users actually ask for it.