### PR TITLE
jshint Fixes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,5 +12,9 @@
   "sub": true,
   "trailing": true,
   "undef": true,
-  "unused": true
+  "unused": true,
+  "predef": [
+      "require",
+      "global"
+  ]
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -233,7 +233,7 @@ function attachWorkerHelpers(worker) {
 
       // worker has not acknowledged itself in 60 sec, reopen url
       client.changeUrl(self.id, { url: self.buildUrl() }, function () {
-        logger.debug("[%s] Sent Request to reload url", self.getTestBrowserInfo());
+        logger.debug('[%s] Sent Request to reload url', self.getTestBrowserInfo());
       });
 
     }, ackTimeout * 1000);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -4,7 +4,6 @@ var http = require('http'),
 var ProxyServer = {
   onRequest: function(client_req, client_res, host, callback) {
     var proxyUrl = url.parse(host);
-    var path = url.parse(host);
     var options = {
       path: client_req.url,
       hostname: proxyUrl.hostname,
@@ -14,7 +13,7 @@ var ProxyServer = {
     };
 
     var proxy = http.request(options, function (res) {
-      data = "";
+      var data = '';
       res.on('data', function(chunk) {
         data += chunk;
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,8 +7,6 @@ var Log = require('./logger'),
 
 String.prototype.escapeSpecialChars = function() {
   return this.replace(/\n/g, '\\n')
-  // TODO what is this supposed to do? JSHint considers this "Bad or unnecessary escaping."
-  .replace(/\\s/g, '\s')
   .replace(/\\\'/, '\'');
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,13 @@ var Log = require('./logger'),
 
 String.prototype.escapeSpecialChars = function() {
   return this.replace(/\n/g, '\\n')
-  .replace(/\\\'/, '\'');
+  .replace(/\r/g, '\\r')
+  .replace(/\t/g, '\\t')
+  .replace(/\f/g, '\\f')
+  .replace(/\u0008/g, '\\u0008')  // \b
+  .replace(/\v/g, '\\u000b')      // \v
+  .replace(/\0/g, '\\u0000')      // \0
+  .replace(/\\\'/, '\'');         // TODO: check why this exists
 };
 
 var titleCase = function toTitleCase(str) {

--- a/tests/unit/utils_spec.js
+++ b/tests/unit/utils_spec.js
@@ -6,7 +6,7 @@ describe('Utilities', function(){
     assert.equal("Hello", utils.titleCase("hello"));
     assert.equal("Are You Serious?", utils.titleCase("are you serious?"));
   });
-  
+
   it('should generate 32 char uuid', function(){
     assert.equal(5, utils.uuid().split("-").length);
     assert.equal(32 + 4, utils.uuid().length);
@@ -16,7 +16,7 @@ describe('Utilities', function(){
     assert.notEqual(utils.uuid(), utils.uuid());
     assert.notEqual(utils.uuid(), utils.uuid());
   });
-  
+
   it('should generate proper browser string for config', function(){
     var chrome_mac = {os: "OS X", os_version: "Mavericks", "browser": "chrome", "browser_version": "latest"};
     var chrome_windows = {os: "Windows", os_version: "XP", "browser": "chrome", "browser_version": "latest"};
@@ -24,16 +24,28 @@ describe('Utilities', function(){
     var ie_windows = {os: "Windows", os_version: "7", "browser": "ie", "browser_version": "9.0"};
     var iOS = {os: "iOS", os_version: "6.0", device: "iPhone 5"};
     var androidConfig = {os: "android", os_version: "4.1"};
-    
+
     assert.equal("OS X Mavericks, Chrome latest", utils.browserString(chrome_mac));
     assert.equal("Windows XP, Chrome latest", utils.browserString(chrome_windows));
     assert.equal("Windows 7, Internet Explorer 9.0", utils.browserString(ie_windows));
     assert.equal("iOS 6.0, iPhone 5", utils.browserString(iOS));
     assert.equal("android 4.1", utils.browserString(androidConfig));
   });
-  
+
   it('should return number of keys for this object', function(){
     assert.equal(0, utils.objectSize({}));
     assert.equal(1, utils.objectSize({a: 2}));
+  });
+
+  it('should escape special characters incompatible with JSON.parse', function () {
+    var testString = '{"tracebacks":[{"actual":null,"message":"Died on test #1     at http://localhost:8888/test/main/globals.js:43:7\n    at http://localhost:8888/test/main/globals.js:67:2: Error","testName":"globals: Exported assertions"}]}';
+    var expectString = '{"tracebacks":[{"actual":null,"message":"Died on test #1     at http://localhost:8888/test/main/globals.js:43:7\\n    at http://localhost:8888/test/main/globals.js:67:2: Error","testName":"globals: Exported assertions"}]}';
+
+    var malformedJson = '{ "key" : "Bad\njson contains\rall\tsorts\bof\vhorrible\0 & nasty\fescape sequences" }';
+    var expectJson = { "key" : "Bad\njson contains\rall\tsorts\bof\u000bhorrible\u0000 & nasty\fescape sequences" };
+
+    assert.throws(function () { JSON.parse(testString); }, SyntaxError, 'JSON.parse fails');
+    assert.equal(testString.escapeSpecialChars(), expectString);
+    assert.equal(JSON.parse(malformedJson.escapeSpecialChars()).key, expectJson.key);
   });
 });


### PR DESCRIPTION
Handles `Bad or unnecessary escaping` jshint error and a few other lint errors.

Closes #99.