### PR TITLE
Fix for failing Travis builds

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -70,7 +70,8 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
       options.push('-force');
       options.push('-onlyAutomate');
     } else {
-      options.push('-localIdentifier ' + uniqueIdentifier);
+      options.push('-localIdentifier');
+      options.push(uniqueIdentifier);
     }
 
     var proxy = config.proxy;


### PR DESCRIPTION
In environments like Travis, the `-localIdentifier` option [is set](https://github.com/browserstack/browserstack-runner/blob/2e3f4a3c42f909cf3b957cd5bdfa5567a7e5f0a8/lib/config.js#L76) for the `BrowserStackLocal` binary used for creating the local tunnel. 

For some inexplicable reason, child_process.execFile seems to require each args array element to be an independent fragment of the command - for e.g. [ '-localIdentifier ' + 'ID:1' ] vs. [ '-localIdentifier', 'ID:1' ]. I have no idea why it works that way.

[Working Travis Build with the fix](https://travis-ci.org/shirish87/browserstack-runner-travis-test/builds).

Thanks, @TehShrike and @ausi for helping out.

Fixes #102.