### PR TITLE
Temperary Fix: Sanitize worker uuid

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -223,6 +223,7 @@ exports.Server = function Server(bsClient, workers) {
         query = parseBody(body);
       } catch (e) {}
       var uuid = request.headers['x-worker-uuid'];
+      uuid = uuid && uuid.replace(/[^a-zA-Z0-9\-]/, '');
       var worker = workers[uuid] || {};
       worker._worker_key = uuid;
 


### PR DESCRIPTION
Some android browsers send a request with a '\' character prefixed to every '&',
which causes the uuid to end with a '\'.