### PR TITLE
Verify downloaded binary before attempting to start tunnel

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -89,7 +89,81 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, callback) {
     return options;
   }
 
-  fs.exists(localBinary, function(exists) {
+  function runTunnelCmd(tunnelOptions, subProcessTimeout, processOutputHook, callback) {
+    var isRunning, subProcess, timeoutHandle;
+
+    var callbackOnce = function (err, result) {
+      clearTimeout(timeoutHandle);
+      if (subProcess && isRunning) {
+        try {
+          process.kill(subProcess.pid, 'SIGKILL');
+          subProcess = null;
+        } catch (e) {
+          logger.debug('[%s] failed to kill process:', new Date(), e);
+        }
+      }
+
+      callback && callback(err, result);
+      callback = null;
+    };
+
+    isRunning = true;
+
+    try {
+      subProcess = exec(localBinary, tunnelOptions, function (error, stdout) {
+        isRunning = false;
+
+        if (error) {
+          callbackOnce(new Error('failed to get process output: ' + error));
+        } else if (stdout) {
+          processOutputHook(stdout, callbackOnce);
+        }
+      });
+
+      subProcess.stdout.on('data', function (data) {
+        processOutputHook(data, callbackOnce);
+      });
+    } catch (e) {
+      // Handles EACCESS and other errors when binary file exists,
+      // but doesn't have necessary permissions (among other issues)
+      callbackOnce(new Error('failed to get process output: ' + e));
+    }
+
+    if (subProcessTimeout > 0) {
+      timeoutHandle = setTimeout(function () {
+        callbackOnce(new Error('failed to get process output: command timeout'));
+      }, subProcessTimeout);
+    }
+  }
+
+  function getTunnelBinaryVersion(callback) {
+    var subProcessTimeout = 3000;
+
+    runTunnelCmd([ '-version' ], subProcessTimeout, function (data, done) {
+      var matches = /version\s+(\d+(\.\d+)*)/.exec(data);
+      var version = (matches && matches.length > 2) && matches[1];
+      logger.debug('[%s] Tunnel binary: found version', new Date(), version);
+
+      done(isFinite(version) ? null : new Error('failed to get binary version'), parseFloat(version));
+    }, callback);
+  }
+
+  function verifyTunnelBinary(callback) {
+    logger.debug('[%s] Verifying tunnel binary', new Date());
+
+    fs.exists(localBinary, function (exists) {
+      if (!exists) {
+        logger.debug('[%s] Verifying tunnel binary: file does not exist', new Date());
+        callback(false);
+      } else {
+        getTunnelBinaryVersion(function (err, version) {
+          callback(!err && isFinite(version));
+        });
+      }
+    });
+  }
+
+  verifyTunnelBinary(function (exists) {
     if (exists) {
       tunnelLauncher();
       return;


### PR DESCRIPTION
Performs a simple check with '-version' switch, and on failure causes the binary to be downloaded again.
Fixes #143