### PR TITLE
Update mocha patch to print errors

### DIFF
--- a/lib/_patch/mocha-plugin.js
+++ b/lib/_patch/mocha-plugin.js
@@ -53,14 +53,17 @@
     });
 
     runner.on('end', function() {
-      results = {};
-      results.runtime = (new Date).getTime() - start;
-      results.total = passes + failures;
-      results.passed = passes;
-      results.failed = failures;
-      results.tracebacks = tracebacks;
-      results.url = window.location.pathname;
-      BrowserStack.post("/_report", results, function(){});
+      // delay posting results a little to capture "multiple-done" errors
+      setTimeout(function () {
+        results = {};
+        results.runtime = (new Date).getTime() - start;
+        results.total = passes + failures;
+        results.passed = passes;
+        results.failed = failures;
+        results.tracebacks = tracebacks;
+        results.url = window.location.pathname;
+        BrowserStack.post("/_report", results, function(){});
+      }, 1000);
     });
   };
 

--- a/lib/_patch/mocha-plugin.js
+++ b/lib/_patch/mocha-plugin.js
@@ -48,7 +48,7 @@
       failures += 1;
 
       if (err) {
-        tracebacks.push(err);
+        tracebacks.push(stack(err));
       }
     });
 


### PR DESCRIPTION
Fixes issue with mocha tests printing `Tracebacks: {}` on the console instead of error stack.
Also captures errors that are reported for "multiple done" calls by waiting an extra second.