### PR TITLE
Fix runner worker reuse issue

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -183,7 +183,9 @@ exports.Server = function Server(bsClient, workers) {
       });
 
     } else {
-      bsClient.terminateWorker(worker.id, callback);
+      bsClient.terminateWorker(worker.id, function () {
+        callback(false);
+      });
     }
   }
 


### PR DESCRIPTION
API returns an error `worker is running for 15.206354 secs, minimum life is 60 sec` when terminating workers quickly. Due to a code issue, we end up trying to reuse the existing worker, stalling the run.