### PR TITLE
fix(reporters): Configurable reporters

### DIFF
--- a/lib/_patch/jasmine2-plugin.js
+++ b/lib/_patch/jasmine2-plugin.js
@@ -1,0 +1,28 @@
+(function() {
+  var checker = setInterval(function() {
+    if (!jasmine.running) {
+      var results = {};
+      var specs = jsApiReporter.specs();
+      results.runtime = jsApiReporter.executionTime();
+      results.total = 0;
+      results.passed = 0;
+      results.failed = 0;
+      results.tracebacks = [];
+
+      for (var spec in specs) {
+        if (specs[spec].status === 'passed') {
+            results.passed++;
+        } else {
+            results.tracebacks.push(specs[spec].description);
+            results.failed++;
+        }
+      }
+
+      results.total = results.passed + results.failed;
+      results.url = window.location.pathname;
+      BrowserStack.post('/_report', results, function(){});
+    }
+    clearInterval(checker);
+  }, 1000);
+})();
+

--- a/lib/_patch/mocha-plugin.js
+++ b/lib/_patch/mocha-plugin.js
@@ -1,0 +1,73 @@
+(function() {
+  function stack(err) {
+    var str = err.stack || err.toString();
+
+    if (!~str.indexOf(err.message)) {
+      str = err.message + '\n' + str;
+    }
+
+    if ('[object Error]' == str) {
+      str = err.message;
+    }
+
+    if (!err.stack && err.sourceURL && err.line !== undefined) {
+      str += '\n(' + err.sourceURL + ':' + err.line + ')';
+    }
+    return str.replace(/^/gm, '  ');
+  }
+
+  function title(test) {
+    return test.fullTitle().replace(/#/g, '');
+  }
+
+  var origReporter = mocha._reporter;
+
+  Mocha.BrowserStack = function(runner, root) {
+    origReporter.apply(this, arguments);
+
+    var count = 1,
+      that = this,
+      failures = 0,
+      passes = 0,
+      start = 0,
+      tracebacks = [];
+
+    runner.on('start', function() {
+      start = (new Date).getTime();
+    });
+
+    runner.on('test end', function(test) {
+      count += 1;
+    });
+
+    runner.on('pass', function(test) {
+      passes += 1;
+    });
+
+    runner.on('fail', function(test, err) {
+      failures += 1;
+
+      if (err) {
+        tracebacks.push(stack(err));
+      }
+    });
+
+    runner.on('end', function() {
+      // delay posting results a little to capture "multiple-done" errors
+      setTimeout(function () {
+        results = {};
+        results.runtime = (new Date).getTime() - start;
+        results.total = passes + failures;
+        results.passed = passes;
+        results.failed = failures;
+        results.tracebacks = tracebacks;
+        results.url = window.location.pathname;
+        BrowserStack.post("/_report", results, function(){});
+      }, 1000);
+    });
+  };
+
+  Mocha.BrowserStack.prototype = origReporter.prototype;
+
+  return Mocha.BrowserStack;
+})();

--- a/lib/_patch/qunit-plugin.js
+++ b/lib/_patch/qunit-plugin.js
@@ -1,0 +1,62 @@
+// For logging assertions on the console, here's what grunt-contrib-qunit uses:
+// https://github.com/gruntjs/grunt-contrib-qunit/blob/784597023e7235337ca9c0651aa45124a2d72341/tasks/qunit.js#L45
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    require(['qunit'], factory);
+  } else {
+    factory(QUnit);
+  }
+}(function(QUnit) {
+  var failedAssertions = [];
+  var options,
+    currentModule,
+    currentTest,
+    setTimeoutVariable;
+  var pendingTest = {};
+
+  var testTimeout = function() {
+    var error = {
+      testName: currentTest,
+      message: "Stuck on this test for 60 sec."
+    };
+
+    BrowserStack.post('/_progress', {
+      tracebacks: [error]
+    }, function(){});
+  };
+
+  QUnit.testDone(function(details) {
+    var ct = details.module + " - " + details.name;
+    clearTimeout(pendingTest[ct]);
+  });
+
+  QUnit.testStart(function(details) {
+    currentTest = details.module + " - " + details.name;
+    pendingTest[currentTest] = setTimeout(function() {
+      testTimeout(currentTest);
+    }, 60000);
+  });
+
+  QUnit.log(function(details) {
+    if (details.result) {
+      return;
+    }
+
+    var error = {
+      actual: details.actual,
+      expected: details.expected,
+      message: details.message,
+      source: details.source,
+      testName:( details.module + ": " + details.name)
+    };
+
+    BrowserStack.post('/_progress', {
+      tracebacks: [error]
+    }, function(){});
+  });
+
+  QUnit.done(function(results) {
+    results.url = window.location.pathname;
+    BrowserStack.post("/_report", results, function(){});
+  });
+}));

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,16 +39,14 @@ exports.Server = function Server(bsClient, workers) {
       ];
 
       var framework_scripts = {
-        'jasmine': ['jasmine-jsreporter.js', 'jasmine-plugin.js']
+        'qunit': ['qunit-plugin.js'],
+        'jasmine': ['jasmine-jsreporter.js', 'jasmine-plugin.js'],
+        'jasmine2': ['jasmine2-plugin.js'],
+        'mocha': ['mocha-plugin.js']
       };
 
       var filePath = path.relative(process.cwd(), filename);
       var pathMatches = (testFilePaths.indexOf(filePath) !== -1);
-
-      var jsReportersPath = path.join(__dirname, '../node_modules/js-reporters/dist/js-reporters.js');
-      var jsReportersScript = fs.readFileSync(jsReportersPath, {
-        encoding: 'utf8'
-      });
 
       if (pathMatches) {
         var framework = config['test_framework'];
@@ -59,7 +57,26 @@ exports.Server = function Server(bsClient, workers) {
           patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
         });
 
-        patch += '<script type="text/javascript">' + jsReportersScript + '</script>';
+        var shouldUseJsReporter = true;
+        if(config.use_js_reporters == null) {
+          request.rawHeaders.forEach(function(header) {
+            utils.avoidJsReporterHeaders.forEach(function(avoidHeader) {
+              if(header.toLowerCase().indexOf(avoidHeader.toLowerCase()) > -1) {
+                shouldUseJsReporter = false;
+              }
+            });
+          });
+        } else {
+          shouldUseJsReporter = (typeof config.use_js_reporters === 'boolean') ? config.use_js_reporters : true;
+        }
+
+        if(shouldUseJsReporter) {
+          var jsReportersPath = path.join(__dirname, '../node_modules/js-reporters/dist/js-reporters.js');
+          var jsReportersScript = fs.readFileSync(jsReportersPath, {
+            encoding: 'utf8'
+          });
+          patch += '<script type="text/javascript">' + jsReportersScript + '</script>';
+        }
 
         // adding framework scripts
         if (framework === 'jasmine') {
@@ -67,7 +84,20 @@ exports.Server = function Server(bsClient, workers) {
             patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
           });
           patch += '<script type="text/javascript">jasmine.getEnv().addReporter(new jasmine.JSReporter());</script>\n';
-        } else {
+        } else if (!shouldUseJsReporter && framework === 'jasmine2') {
+          framework_scripts['jasmine2'].forEach(function(script) {
+            patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
+          });
+        } else if (!shouldUseJsReporter && framework === 'mocha') {
+          framework_scripts['mocha'].forEach(function(script) {
+            patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
+          });
+          patch += '<script type="text/javascript">mocha.reporter(Mocha.BrowserStack);</script>\n';
+        } else if (!shouldUseJsReporter && framework === 'qunit') {
+          framework_scripts['qunit'].forEach(function(script) {
+            patch += '<script type="text/javascript" src="/_patch/' + script + '"></script>\n';
+          });
+        } else if (shouldUseJsReporter) {
           patch += '<script type="text/javascript" src="/_patch/reporter.js"></script>\n';
         }
         patch += '</' + tag_name + '>';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,4 +130,4 @@ exports.uuid = uuid;
 exports.browserString = browserString;
 exports.objectSize = objectSize;
 exports.alertBrowserStack = alertBrowserStack;
-exports.avoidJsReporterHeaders = [ 'MSIE 7.0', 'MSIE 8.0' ];
+exports.avoidJsReporterHeaders = [ 'MSIE 6.0', 'MSIE 7.0', 'MSIE 8.0' ];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -130,3 +130,4 @@ exports.uuid = uuid;
 exports.browserString = browserString;
 exports.objectSize = objectSize;
 exports.alertBrowserStack = alertBrowserStack;
+exports.avoidJsReporterHeaders = [ 'MSIE 7.0', 'MSIE 8.0' ];

--- a/tests/external-tests.js
+++ b/tests/external-tests.js
@@ -62,6 +62,102 @@ var repositories = [
     test_framework: 'qunit',
     browsers: [
       {
+        'browser': 'ie',
+        'browser_version': '8',
+        'os': 'Windows',
+        'os_version': '7'
+      }
+    ],
+    test_path: [
+      'test/index.html'
+    ],
+    expected_results: {
+      tests: 510,
+      passed: 510,
+      failed: 0
+    }
+  },
+  {
+    name: 'mocha',
+    tag: 'v2.4.5',
+    url: 'https://github.com/mochajs/mocha.git',
+    test_framework: 'mocha',
+    browsers: [
+      {
+        'browser': 'ie',
+        'browser_version': '7',
+        'os': 'Windows',
+        'os_version': 'XP'
+      }
+    ],
+    test_path: [
+      'test/browser/index.html',
+      'test/browser/large.html',
+      'test/browser/opts.html'
+    ],
+    expected_results: {
+      tests: 89,
+      passed: 20,
+      failed: 69
+    }
+  },
+  {
+    name: 'spine',
+    tag: 'v.1.6.2',
+    url: 'https://github.com/spine/spine.git',
+    test_framework: 'jasmine2',
+    browsers: [
+      {
+        'browser': 'ie',
+        'browser_version': '8',
+        'os': 'Windows',
+        'os_version': 'XP'
+      }
+    ],
+    test_path: [
+      'test/index.html'
+    ],
+    expected_results: {
+      tests: 161,
+      passed: 108,
+      failed: 53
+    }
+  },
+  {
+    name: 'spine',
+    tag: 'v1.0.0',
+    url: 'https://github.com/spine/spine.git',
+    test_framework: 'jasmine',
+    browsers: [
+      {
+        'browser': 'ie',
+        'browser_version': '8',
+        'os': 'Windows',
+        'os_version': '7'
+      }
+    ],
+    test_path: [
+      'test/index.html'
+    ],
+    patches: [
+      {
+        find: 'jasmine.getEnv().execute();',
+        replace: 'window.onload = function () { jasmine.getEnv().execute(); };'
+      }
+    ],
+    expected_results: {
+      tests: 63,
+      passed: 59,
+      failed: 4
+    }
+  },
+  {
+    name: 'qunit',
+    tag: '1.21.0',
+    url: 'https://github.com/jquery/qunit.git',
+    test_framework: 'qunit',
+    browsers: [
+      {
         'browser': 'firefox',
         'browser_version': '44.0',
         'os': 'OS X',

--- a/tests/external-tests.js
+++ b/tests/external-tests.js
@@ -131,9 +131,9 @@ var repositories = [
     browsers: [
       {
         'browser': 'ie',
-        'browser_version': '8',
+        'browser_version': '6',
         'os': 'Windows',
-        'os_version': '7'
+        'os_version': 'XP'
       }
     ],
     test_path: [
@@ -146,9 +146,9 @@ var repositories = [
       }
     ],
     expected_results: {
-      tests: 63,
-      passed: 59,
-      failed: 4
+      tests: 58,
+      passed: 53,
+      failed: 5
     }
   },
   {


### PR DESCRIPTION
Using JS Reporters in IE8 and lower gives [an error in developer console](https://s3.amazonaws.com/testautomation/3c46e2726c1604cb2a9acd70919162c07021473c/js-screenshot-1469617775.png) saying `'JsReporters' is undefined` and `prototype is null or not an object`. This issue is presently in the `master` branch and has not been released yet. 

- Added support to use `use_js_reporters` in `browserstack.json` config file with value as boolean indicating whether to use JsReporters or individual patches for frameworks. Its default value is `true` ie. to use JsReporters except in case of IE8 and lower (we check the request headers of the originating request).