### PR TITLE
[Fix] Server output logs for console.log

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -349,7 +349,11 @@ exports.Server = function Server(bsClient, workers, config, callback) {
     },
     '_log': function logHandler(uri, body, request, response) {
       var uuid = getWorkerUuid(request);
-      var query = body;
+      var query = null;
+      try {
+        query = CircularJSON.parse(body);
+      } catch (e) {}
+      
       logger.trace('[%s] _log', ((uuid && workers[uuid]) || {}).id, query);
 
       var logged = false;

--- a/lib/server.js
+++ b/lib/server.js
@@ -352,7 +352,9 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       var query = null;
       try {
         query = CircularJSON.parse(body);
-      } catch (e) {}
+      } catch (e) {
+        query = body;
+      }
       
       logger.trace('[%s] _log', ((uuid && workers[uuid]) || {}).id, query);
 
@@ -406,3 +408,5 @@ exports.Server = function Server(bsClient, workers, config, callback) {
     });
   });
 };
+
+exports.logger = logger;


### PR DESCRIPTION
Changes console.log line logs from
`[OS X Sierra, Firefox 50.0] {"arguments":["'Random Stuff'"]}`
to
`[OS X Sierra, Firefox 50.0] Random Stuff`