### PR TITLE
Fix for Issue #174 (exception seen in Travis)

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -276,7 +276,7 @@ var statusPoller = {
         }).forEach(function(_worker) {
           var workerData = workerKeys[_worker.id];
           var worker = workers[workerData.key];
-          if (worker.launched) {
+          if (!worker || worker.launched) {
             return;
           }
 


### PR DESCRIPTION
The issue fixed by this pull request is documented here: https://github.com/browserstack/browserstack-runner/issues/174.

The test terminates while executing `if(worker.launched)` on line #279 in `bin/cli.js`. This occurs because the `worker` variable is undefined. On a study of the variables involved, it seems that this is being caused by a race condition causing `_workers` and `workers` variables to be out of sync, eventually leading to `worker` being undefined.

Changing the condition from `worker.launched` to `!worker || worker.launched` helps avoiding the exception and it was verified that the Travis builds are now working. Here are the builds passing after this change was tried: https://travis-ci.org/reeteshranjan/browse.js/builds/227355846, https://travis-ci.org/reeteshranjan/browse.js/builds/227355071].

Whether this change would cause any side-effect was analyzed. It turns out that stopping the processing in the `if` block starting at line #279 does not cause any side-effect. It is only a safe decision that in case the `worker` variable is falsy, there is no way one can proceed.