### PR TITLE
Fix for Issue #177

### DIFF
--- a/lib/_patch/jasmine-jsreporter.js
+++ b/lib/_patch/jasmine-jsreporter.js
@@ -75,10 +75,7 @@
                 description : specs[i].description,
                 durationSec : specs[i].durationSec,
                 passed : specs[i].results().passedCount === specs[i].results().totalCount,
-                skipped : specs[i].results().skipped,
-                passedCount : specs[i].results().passedCount,
-                failedCount : specs[i].results().failedCount,
-                totalCount : specs[i].results().totalCount
+                results : specs[i].results()
             };
             suiteData.passed = !suiteData.specs[i].passed ? false : suiteData.passed;
             suiteData.durationSec += suiteData.specs[i].durationSec;

--- a/lib/_patch/jasmine-plugin.js
+++ b/lib/_patch/jasmine-plugin.js
@@ -3,8 +3,10 @@
     for (var i = 0; i < suite.specs.length; ++i) {
       if (suite.specs[i].passed){
         results.passed++;
+      }
+      else if(suite.specs[i].results.skipped) {
+        results.skipped++;
       } else {
-        results.tracebacks.push(suite.specs[i].description);
         results.failed++;
       }
     }
@@ -26,7 +28,7 @@
       results.total = 0;
       results.passed = 0;
       results.failed = 0;
-      results.tracebacks = [];
+      results.skipped = 0;
 
       for (var i = 0; i < report.suites.length; ++i) {
         if (report.suites[i]) {
@@ -34,9 +36,10 @@
         }
       }
 
-      results.total = results.passed + results.failed;
+      results.total = results.passed + results.failed + results.skipped;
 
       results.url = window.location.pathname;
+      results.report = report
       BrowserStack.post("/_report", results, function(){});
       clearInterval(checker);
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,7 +56,9 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       runtime : results.runtime
     };
     function recurseThroughSuites(jasmineSuite, par) {
-      if(!jasmineSuite) return
+      if(!jasmineSuite) {
+        return;
+      }
       var suite = {
         name : jasmineSuite.description,
         fullName: [ ],

--- a/lib/server.js
+++ b/lib/server.js
@@ -39,6 +39,101 @@ exports.Server = function Server(bsClient, workers, config, callback) {
     return browserReport;
   }
 
+  function reformatJasmineReport(browserReport) {
+    var results = browserReport.suites;
+    browserReport.tests = browserReport.tests || [ ];
+    browserReport.suites = {
+      fullName : [ ],
+      childSuites : [ ],
+      tests : [ ],
+      status : !results.failed ? 'passed' : 'failed',
+      testCounts : {
+        passed : results.passed,
+        failed : results.failed,
+        skipped : results.skipped,
+        total : results.total,
+      },
+      runtime : results.runtime
+    };
+    function recurseThroughSuites(jasmineSuite, par) {
+      var suite = {
+        name : jasmineSuite.description,
+        fullName: [ ],
+        childSuites : [ ],
+        tests: [ ],
+        status : jasmineSuite.passed ? 'passed' : 'failed',
+        testCounts : {
+          passed : 0,
+          failed : 0,
+          skipped: 0,
+          total: 0
+        },
+        runtime: 0
+      };
+      if(par.name) {
+        suite.fullName.push(par.name);
+      }
+      suite.fullName.push(jasmineSuite.description);
+      jasmineSuite.specs.forEach(function(spec) {
+        var test = {
+          name : spec.description,
+          suiteName : suite.decription,
+          fullName : [
+          ],
+          status : spec.passed ?  'passed' : (spec.results.skipped ? 'skipped' : 'failed'),
+          runtime : spec.durationSec,
+          errors : [ ],
+          assertions : [ ]
+        };
+        Array.prototype.push.apply(test.fullName, suite.fullName);
+        test.fullName.push(spec.description);
+        if(!spec.passed) {
+          spec.results.items_.forEach(function(jasmineItem) {
+            if(!jasmineItem.passed_) {
+              var detail = {
+                passed : false
+              };
+              if('message' in jasmineItem) {
+                detail.message = jasmineItem.message;
+              }
+              if('actual' in jasmineItem) {
+                detail.actual = jasmineItem.actual;
+              }
+              if('expected' in jasmineItem) {
+                detail.expected = jasmineItem.expected;
+              }
+              if('trace' in jasmineItem) {
+                detail.stack = jasmineItem.trace.message || jasmineItem.trace.stack;
+              }
+              test.errors.push(detail);
+              test.assertions.push(detail);
+            }
+          });
+        }
+        suite.tests.push(test);
+        browserReport.tests.push(test);
+        if(spec.passed) {
+          ++suite.testCounts.passed;
+        }
+        else if(spec.skipped) {
+          ++suite.testCounts.skipped;
+        }
+        else {
+          ++suite.testCounts.failed;
+        }
+        ++suite.testCounts.total;
+        suite.runtime += spec.durationSec;
+      });
+      jasmineSuite.suites.forEach(function(childSuite) {
+        recurseThroughSuites(childSuite, suite);
+      });
+      par.childSuites.push(suite);
+    }
+    results.report.suites.forEach(function(jasmineSuite) {
+      recurseThroughSuites(jasmineSuite, browserReport.suites);
+    });
+  }
+
   function handleFile(filename, request, response, doNotUseProxy) {
     var url_parts = url.parse(request.url, true);
     var query = url_parts.query;
@@ -293,6 +388,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
           color = ( query.total !== query.passed ) ? 'red' : 'green';
           logger.info('[%s] ' + chalk[color](( query.total !== query.passed ) ? 'Failed:' : 'Passed:') + ' %d tests, %d passed, %d failed; ran for %dms', browserInfo, query.total, query.passed, query.failed, query.runtime);
           config.status += query.failed;
+          reformatJasmineReport(browserReport);
         } else if(query.testCounts) {
           color = query.status === 'failed' ? 'red' : 'green';
           logger.info('[%s] ' + chalk[color](query.status === 'failed' ? 'Failed:' : 'Passed:') + ' %d tests, %d passed, %d failed, %d skipped; ran for %dms', browserInfo, query.testCounts.total, query.testCounts.passed, query.testCounts.failed, query.testCounts.skipped, query.runtime);

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,6 +56,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       runtime : results.runtime
     };
     function recurseThroughSuites(jasmineSuite, par) {
+      if(!jasmineSuite) return
       var suite = {
         name : jasmineSuite.description,
         fullName: [ ],

--- a/tests/external-tests.js
+++ b/tests/external-tests.js
@@ -131,9 +131,9 @@ var repositories = [
     browsers: [
       {
         'browser': 'safari',
-        'browser_version': '5.1',
+        'browser_version': '9.0',
         'os': 'OS X',
-        'os_version': 'Snow Leopard'
+        'os_version': 'El Capitan'
       }
     ],
     test_path: [


### PR DESCRIPTION
### Cause

The code that works with `Jasmine` is completely different from the one working with `Mocha` and `QUnit`. The results sent to `_report` api in case of `Jasmine` have very limited information resulting in the case as described in this issue.

It was found that the `Jasmine` reports are as good as `Mocha` ones and it's our code that does not let it pass through in its entirety causing the limited information.

### Modifications

- **jasmine-jsreporter.js** - It has the code that prepares per test suite report, and cuts out detailed information. It was modified to retain detailed information. Also some 'summarization' attributes turned out to be duplicate state post these modifications, and they were removed.
- **jasmine-plugin.js** - It has code that further summarizes the reports created per suite in `jasmine-jsreporter.js` before making a call to the `_report` api. It was modified to retain detailed information.
- **server.js** - for `Jasmine` case, a 'reformatting' adapter function is added. With the changes done in above files, detailed information as good as `Mocha` is available; however, the structure of the information is different. This function adapts the structure such that the final reports are seen in the format as in `README.md`. This function is called in the handler for `_report` api.

### Limitations/Differences

- There is no equivalent of `_progress` api added. The `tests` attribute at the topmost level in the final test reports is built in the `_progress` api handler in case of `Mocha`. This api gets called as each test completes, in case of `Mocha`. In `Jasmine` case, we build the `tests` attribute completely in the handler for `_report` api call.
- In case of `Mocha`, whether it's an assertion failure or an uncaught exception, stack trace is available for both cases. In `Jasmine` case, stack trace is available only in case of uncaught exceptions. In case of assertion failures, `Jasmine` provides only a message, not a trace. This is a limitation that we do not have any control over as it exists in the source test reports data output by `Jasmine`.