### PR TITLE
Add `tunnel_pid` and `test_server_port` settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,12 @@ To run browser tests on BrowserStack infrastructure, you need to create a `brows
  * `key`: BrowserStack [access key](https://www.browserstack.com/accounts/local-testing) (Or `BROWSERSTACK_KEY` environment variable)
  * `test_path`: Path to the test page which will run the tests when opened in a browser.
  * `test_framework`: Specify test framework which will run the tests. Currently supporting qunit, jasmine, jasmine2 and mocha.
+ * `test_server_port`: Specify test server port that will be opened from BrowserStack. If not set the default port 8888 will be used. Find a [list of all supported ports on browerstack.com](https://www.browserstack.com/question/664).
  * `timeout`: Specify worker timeout with BrowserStack.
  * `browsers`: A list of browsers on which tests are to be run. Find a [list of all supported browsers and platforms on browerstack.com](https://www.browserstack.com/list-of-browsers-and-platforms?product=js_testing).
  * `build`: A string to identify your test run in Browserstack.  In `TRAVIS` setup `TRAVIS_COMMIT` will be the default identifier.
  * `proxy`: Specify a proxy to use for the local tunnel. Object with `host`, `port`, `username` and `password` properties.
+ * `tunnel_pid`: Specify a path to file to save the tunnel process id into.
 
 A sample configuration file:
 
@@ -181,6 +183,7 @@ A sample configuration file:
   "key": "<access key>",
   "test_framework": "qunit|jasmine|jasmine2|mocha",
   "test_path": ["relative/path/to/test/page1", "relative/path/to/test/page2"],
+  "test_server_port": "8899",
   "browsers": [
     {
       "browser": "ie",

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,7 +9,6 @@ var Log = require('../lib/logger'),
     tunnel = require('tunnel'),
     http = require('http'),
     ConfigParser = require('../lib/configParser').ConfigParser,
-    serverPort = 8888,
     config,
     server,
     timeout,
@@ -106,7 +105,7 @@ function getTestBrowserInfo(browserString, path) {
 }
 
 function buildTestUrl(test_path, worker_key, browser_string) {
-  var url = 'http://localhost:' + serverPort + '/' + test_path;
+  var url = 'http://localhost:' + config.test_server_port + '/' + test_path;
 
   var querystring = qs.stringify({
     _worker_key: worker_key,
@@ -119,11 +118,11 @@ function buildTestUrl(test_path, worker_key, browser_string) {
 }
 
 function launchServer(config, callback) {
-  logger.trace('launchServer:', serverPort);
-  logger.debug('Launching server on port:', serverPort);
+  logger.trace('launchServer:', config.test_server_port);
+  logger.debug('Launching server on port:', config.test_server_port);
 
   server = new Server(client, workers, config, callback);
-  server.listen(parseInt(serverPort, 10));
+  server.listen(parseInt(config.test_server_port, 10));
 }
 
 function launchBrowser(browser, path) {
@@ -380,7 +379,7 @@ function runTests(config, callback) {
       launchServer(config, runTestsCallback);
 
       logger.trace('runTests: creating tunnel');
-      tunnel = new Tunnel(config.key, serverPort, config.tunnelIdentifier, config, function (err) {
+      tunnel = new Tunnel(config.key, config.test_server_port, config.tunnelIdentifier, config, function (err) {
         if(err) {
           cleanUpAndExit(null, err, [], callback);
         } else {

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -4,7 +4,7 @@ var todo = process.argv[2],
   path = require('path'),
   config;
 
-if (todo === '--verbose') {
+if (process.argv.indexOf('--verbose') !== -1) {
   global.logLevel = process.env.LOG_LEVEL || 'debug';
 } else {
   global.logLevel = 'info';
@@ -34,6 +34,12 @@ try {
     console.error(e.stack);
     throw new Error('Invalid configuration in `browserstack.json` file');
   }
+}
+
+// extract a path to file to store tunnel pid
+var matches, pid = process.argv.find(function (param) { return param.indexOf('--pid') !== -1; });
+if (pid && (matches = /-pid=([\w\/\.-]+)/g.exec(pid))) {
+  config.tunnel_pid = matches[1];
 }
 
 var runner = require('./cli.js');

--- a/lib/config.js
+++ b/lib/config.js
@@ -81,4 +81,8 @@ exports.config = function(config) {
   for (var key in config) {
     this[key] = config[key];
   }
+
+  if (!this.test_server_port) {
+    this.test_server_port = 8888;
+  }
 };

--- a/lib/local.js
+++ b/lib/local.js
@@ -2,7 +2,9 @@ var Log = require('./logger'),
   logger = new Log(global.logLevel || 'info'),
   exec = require('child_process').execFile,
   fs = require('fs'),
+  path = require('path'),
   https = require('https'),
+  utils = require('./utils'),
   windows = ((process.platform.match(/win32/) || process.platform.match(/win64/)) !== null),
   localBinary = __dirname + '/BrowserStackLocal' + (windows ? '.exe' : '');
 
@@ -55,6 +57,11 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, config, callback) {
       }
     });
 
+    if (config.tunnel_pid) {
+      utils.mkdirp(path.dirname(config.tunnel_pid));
+      fs.writeFile(config.tunnel_pid, subProcess.pid);
+    }
+
     that.process = subProcess;
   }
 
@@ -99,6 +106,10 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, config, callback) {
           subProcess = null;
         } catch (e) {
           logger.debug('[%s] failed to kill process:', new Date(), e);
+        } finally {
+          if (config.tunnel_pid) {
+            fs.unlink(config.tunnel_pid, function () {});
+          }
         }
       }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,6 @@
+var fs = require('fs'),
+  path = require('path');
+
 String.prototype.escapeSpecialChars = function() {
   return this.replace(/\n/g, '\\n')
   .replace(/\r/g, '\\r')
@@ -43,7 +46,18 @@ var objectSize = function objectSize(obj) {
   return size;
 };
 
+var mkdirp = function mkdirp(filepath) {
+  var dirname = path.dirname(filepath);
+  if (!fs.existsSync(dirname)) {
+      mkdirp(dirname);
+  }
+  if (!fs.existsSync(filepath)) {
+    fs.mkdirSync(filepath);
+  }
+};
+
 exports.titleCase = titleCase;
 exports.uuid = uuid;
 exports.browserString = browserString;
 exports.objectSize = objectSize;
+exports.mkdirp = mkdirp;


### PR DESCRIPTION
* Add support of `config.tunnel_pid` and cli `—pid` param
  - It should be a string with a filename to save process id
  - It will allow external process to control the tunnel process
  - If automated jobs for browserstack hanged or shutdown, we want to kill previous tunnel process manually before starting tests again.
* Add support of `config.test_server_port` param
  - If not set, the default 8888 port is used
  - List of support ports: https://www.browserstack.com/question/664