### PR TITLE
Add an option of exit with fail on tests fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ To run browser tests on BrowserStack infrastructure, you need to create a `brows
  * `browsers`: A list of browsers on which tests are to be run. Find a [list of all supported browsers and platforms on browerstack.com](https://www.browserstack.com/list-of-browsers-and-platforms?product=js_testing).
  * `build`: A string to identify your test run in Browserstack.  In `TRAVIS` setup `TRAVIS_COMMIT` will be the default identifier.
  * `proxy`: Specify a proxy to use for the local tunnel. Object with `host`, `port`, `username` and `password` properties.
+ * `exit_with_fail`: If set to true the cli process will exit with fail if any of the tests failed. Useful for automatic build systems.
 
 A sample configuration file:
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -306,10 +306,11 @@ var statusPoller = {
                   }
 
                   logger.trace('[%s] worker.activityTimeout: all tests done', worker.id, config.status && 'with failures');
+                  var testsFailedError = utils.createTestsFailedError(config);
                   if(server && server.reports) {
-                    callback(null, server.reports);
+                    callback(testsFailedError, server.reports);
                   } else {
-                    callback(null, {});
+                    callback(testsFailedError, {});
                   }
                 }
               } else {
@@ -336,10 +337,11 @@ var statusPoller = {
                   }
 
                   logger.trace('[%s] worker.testActivityTimeout: all tests done', worker.id, config.status && 'with failures');
+                  var testsFailedError = utils.createTestsFailedError(config);
                   if(server && server.reports) {
-                    callback(null, server.reports);
+                    callback(testsFailedError, server.reports);
                   } else {
-                    callback(null, {});
+                    callback(testsFailedError, {});
                   }
                 }
               } else {

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -39,9 +39,13 @@ try {
 var runner = require('./cli.js');
 runner.run(config, function(err) {
   if(err) {
-    console.error(err);
-    console.error(err.stack);
-    console.error('Invalid Command');
+    if (err.name === 'TestsFailedError') {
+      console.error('Exit with fail due to some tests failure.');
+    } else {
+      console.error(err);
+      console.error(err.stack);
+      console.error('Invalid Command');
+    }
     process.exit(1);
   }
   process.exit(0);

--- a/lib/server.js
+++ b/lib/server.js
@@ -340,7 +340,8 @@ exports.Server = function Server(bsClient, workers, config, callback) {
             }
 
             logger.trace('[%s] _report: checkAndTerminateWorker: all tests done', worker.id, config.status && 'with failures');
-            callback(null, reports);
+            var testsFailedError = utils.createTestsFailedError(config);
+            callback(testsFailedError, reports);
           }
         });
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,17 @@ var objectSize = function objectSize(obj) {
   return size;
 };
 
+var createTestsFailedError = function createTestsFailedError(config) {
+  var error = null;
+  if (config.status && config.exit_with_fail) {
+    error = new Error('Some tests failed.');
+    error.name = 'TestsFailedError';
+  }
+  return error;
+};
+
 exports.titleCase = titleCase;
 exports.uuid = uuid;
 exports.browserString = browserString;
 exports.objectSize = objectSize;
+exports.createTestsFailedError = createTestsFailedError;


### PR DESCRIPTION
This is a boolean flag in config. If it is set to true, the CLI process with exist with fail if any of the tests failed. This is super convenient in automatic build systems, like Jenkins. Where we normally want to fail the job if any of the tests have failed.