### PR TITLE
Add support for nodeunit.

### DIFF
--- a/lib/_patch/reporter.js
+++ b/lib/_patch/reporter.js
@@ -7,6 +7,72 @@
     runner = new JsReporters.JasmineAdapter(jasmine.getEnv());
   } else if (window.mocha) {
     runner = new JsReporters.MochaAdapter(mocha);
+  } else if (window.nodeunit) {
+    console.log('nodeunit adapter');
+
+    runner = {
+      _events: {},
+      on: function (tag, cb) {
+        this._events[tag] = cb;
+      },
+      emit: function (tag, data) {
+        if (this._events[tag]) this._events[tag](data);
+      }
+    };
+
+    var _runModules = nodeunit.runModules;
+
+    nodeunit.runModules = function (modules, opt) {
+        var _opt = {};
+
+        for (var k in opt) {
+          if (Object.prototype.hasOwnProperty.call(opt, k)) {
+            _opt[k] = opt[k];
+          }
+        }
+
+        var suites = [], tests = [];
+
+        _opt.testDone = function (name, assertions) {
+          //console.log('_opt.testDone', name, assertions);
+          var failures = assertions.failures(), errors = [], asserts = [];
+
+          for (var i = 0; i < assertions.length; i++) {
+            var a = assertions[i];
+
+            (a.failed() ? errors : asserts).push(new JsReporters.Assertion(
+              !a.failed(),
+              '',
+              '',
+              a.message || a.method || 'no message',
+              a.error && a.error.stack ? a.error.stack : undefined
+            ));
+          }
+
+          var test = new JsReporters.Test(name, undefined, [],
+            failures ? 'failed' : 'passed',
+            assertions.duration, errors, asserts);
+
+          tests.push(test);
+
+          //console.log('emit(testEnd)', test);
+          runner.emit('testEnd', test);
+
+          if (opt.testDone) opt.testDone(name, assertions);
+        }
+
+        _opt.done = function (assertions) {
+            //console.log('_opt.done', assertions);
+            var suite = new JsReporters.Suite(undefined, [], suites, tests);
+
+            //console.log('emit(runEnd)', suite);
+            runner.emit('runEnd', suite);
+
+            opt.done(assertions);
+        };
+
+        return _runModules(modules, _opt);
+    };
   } else {
     throw new Error('JsReporters: No testing framework was found');
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -162,7 +162,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
 
       if (pathMatches) {
         var framework = config['test_framework'];
-        var tag_name = (framework === 'mocha') ? 'head' : 'body';
+        var tag_name = (framework === 'mocha' || framework === 'nodeunit') ? 'head' : 'body';
         var patch = '$1';
 
         scripts.forEach(function(script) {
@@ -196,7 +196,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       response.writeHead(200, {
         'Content-Type': 'text/html; charset=utf-8'
       });
-      var tag_name = (config['test_framework'] === 'mocha') ? 'head' : 'body';
+      var tag_name = (config['test_framework'] === 'mocha' || config['test_framework'] === 'nodeunit') ? 'head' : 'body';
       var matcher = new RegExp('(.*)<\/' + tag_name + '>'); ///(.*)<\/body>/;
       var patch = getReporterPatch();
       data = data.replace(matcher, patch);


### PR DESCRIPTION
This is the minimal change necessary to get nodeunit tests running
using the browserstack-runner.

Sorry, I didn't want to get all tangled up in that fancy ES6 transpiled
Adapter-pattern goodness which is JsReporters.  Someone else is free to
adapt this pull request and submit it to them, but this patch satisfies
my needs with the smallest amount of code.