### PR TITLE
Use conditional tag matching logic everywhere

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -249,7 +249,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
           }
         });
       } else {
-        patchResponse(responseData, headers, function (data, headers) {
+        patchResponse(responseData && responseData.toString(), headers, function (data, headers) {
           callback && callback(data, headers);
         });
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -187,6 +187,11 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       }
     };
 
+    var getTestingFrameworkMatcher = function() {
+      var tag_name = (config['test_framework'] === 'mocha') ? 'head' : 'body';
+      return new RegExp('(.*)<\/' + tag_name + '>'); ///(.*)<\/body>/;
+    };
+
     var writeResponse = function(err, data) {
 
       if (err) {
@@ -197,8 +202,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       response.writeHead(200, {
         'Content-Type': 'text/html; charset=utf-8'
       });
-      var tag_name = (config['test_framework'] === 'mocha') ? 'head' : 'body';
-      var matcher = new RegExp('(.*)<\/' + tag_name + '>'); ///(.*)<\/body>/;
+      var matcher = getTestingFrameworkMatcher();
       var patch = getReporterPatch();
       data = data.replace(matcher, patch);
 
@@ -210,7 +214,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
       var mimeType = mime.lookup(filename);
       var finalData = data;
       if (mimeType === 'text/html') {
-        var matcher = /(.*)<\/head>/;
+        var matcher = getTestingFrameworkMatcher();
         var patch = getReporterPatch();
         finalData = data.replace(matcher, patch);
         headers['content-length'] = finalData.length;


### PR DESCRIPTION
The logic to match a tag depending on test framework was not consistent when using the test_server configuration option. It would always search for `</head>` and replace that with `</body>` if the framework was not mocha. This PR puts that logic into a function and uses it in both places.