### PR TITLE
Force patched responseData to a string

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -245,7 +245,7 @@ exports.Server = function Server(bsClient, workers, config, callback) {
           }
         });
       } else {
-        patchResponse(responseData, headers, function (data, headers) {
+        patchResponse(responseData && responseData.toString(), headers, function (data, headers) {
           callback && callback(data, headers);
         });
       }


### PR DESCRIPTION
When using `test_server` the response from the server is not forced to a string so the `data.replace` fails. This PR follows the existing pattern and forces the `Buffer` instance to a string before doing the patch.