### PR TITLE
Don't clobber window.console

### DIFF
--- a/lib/_patch/browserstack.js
+++ b/lib/_patch/browserstack.js
@@ -37,18 +37,12 @@
     req.send(data);
   }
 
-  if (typeof console !== 'object') {
-    var console = {};
-    window.console = console;
-  }
-
-  _console_log = console.log;
-
-  console.log = function () {
+  var browserstack_console = console || window.console || {};
+  browserstack_console.log = function () {
     var args = BrowserStack.util.toArray(arguments).map(BrowserStack.util.inspect);
     post('/_log/', { arguments: args }, function () {});
   };
-  console.warn = function () {
+  browserstack_console.warn = function () {
     var args = BrowserStack.util.toArray(arguments).map(BrowserStack.util.inspect);
     post('/_log/', { arguments: args }, function () {});
   };
@@ -60,4 +54,6 @@
   BrowserStack.worker_uuid = getParameterByName('_worker_key');
 
   window.BrowserStack = BrowserStack;
+  window.console = browserstack_console;
+  console = browserstack_console;
 })();

--- a/tests/behaviour/resources/qunit_test1.js
+++ b/tests/behaviour/resources/qunit_test1.js
@@ -1,4 +1,13 @@
 QUnit.module('Partial Tests', function() {
+  QUnit.test('console Tests', function(assert) {
+    // console functions should exist
+    assert.ok(typeof console.info === 'function', 'console.info exists');
+    assert.ok(typeof console.warn === 'function', 'console.warn exists');
+    assert.ok(typeof console.log === 'function', 'console.log exists');
+    assert.ok(typeof console.error === 'function', 'console.error exists');
+    assert.ok(typeof console.debug === 'function', 'console.debug exists');
+  });
+
   QUnit.test('Partial Tests', function(assert) {
     // Fails
     assert.ok(isOdd(2), '2 is an odd number');

--- a/tests/behaviour/runner.js
+++ b/tests/behaviour/runner.js
@@ -146,7 +146,7 @@ describe('Pass/Fail reporting', function() {
       browserstackRunner.run(config, function(err, reports) {
         assert.equal(err, null);
         reports.forEach(function(report) {
-          assert.equal(report.tests.length, 3);
+          assert.equal(report.tests.length, 4);
         });
         done();
       });
@@ -177,7 +177,7 @@ describe('Pass/Fail reporting', function() {
         reports.forEach(function(report) {
           Object.keys(report.tests).forEach(function(reportKey) {
             report.tests[reportKey].assertions.forEach(function(assertion) {
-              assert.notEqual(assertion['message'].match(/\d+ is .*an .* number/), null);
+              assert.notEqual(assertion['message'].match(/(\d+ is .*an .* number|console\..*? exists)/), null);
             });
           });
         });
@@ -216,8 +216,8 @@ describe('Pass/Fail reporting', function() {
       browserstackRunner.run(config, function(err, reports) {
         assert.equal(err, null);
         reports.forEach(function(report) {
-          assert.equal(report.suites.testCounts['total'], 3);
-          assert.equal(report.suites.testCounts['passed'], 1);
+          assert.equal(report.suites.testCounts['total'], 4);
+          assert.equal(report.suites.testCounts['passed'], 2);
           assert.equal(report.suites.testCounts['failed'], 2);
           assert.equal(report.suites.testCounts['skipped'], 0);
         });


### PR DESCRIPTION
Since upgrading a JS framework (Ember 3.x) we use, Browserstack has failed to run our tests correctly, throwing exceptions and causing test failures.

Internally the framework relies on the presence of `window.console.info` and `window.console.debug` but Browserstack clobbers `window.console` and only re-implements `console.log` and `console.warn`.

This change means we will always have all `window.console` methods, but `console.warn` and `console.log` are still overridden for the runner's purposes.