### PR TITLE
Wait for end of copy until spawning tunnel

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -185,12 +185,12 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, config, callback) {
     function(response) {
       response.pipe(file);
 
-      response.on('end', function() {
+      file.on('close', function() {
         fs.chmodSync(localBinary, 0700);
-        setTimeout(function() {
-          tunnelLauncher();
-        }, 100);
-      }).on('error', function(e) {
+        tunnelLauncher();
+      });
+
+      response.on('error', function(e) {
         logger.info('Got error while downloading binary: ' + e.message);
         throw new Error('Got error while downloading binary: ' + e.message);
       });


### PR DESCRIPTION
Fixes the 'spawn ETXTBSY' errors as reported in https://github.com/browserstack/browserstack-runner/issues/209.
The patch is inspired from https://github.com/browserstack/browserstack-local-nodejs/issues/19#issuecomment-256040404.