### PR TITLE
fix: bump yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "resolve": "1.1.7",
     "send": "0.16.2",
     "tunnel": "0.0.3",
-    "yargs": "12.0.1"
+    "yargs": "^15.0.2"
   },
   "devDependencies": {
     "jshint": "2.9.6",
@@ -40,5 +40,8 @@
     "test-ci": "npm run lint && npm run test-unit && npm run test-behaviour && TEST_MODE=all tests/external-tests.js",
     "test": "npm run lint && npm run test-unit && npm run test-behaviour && TEST_MODE=required tests/external-tests.js",
     "update-util": "webpack"
+  },
+  "engine": {
+    "node": ">=8"
   }
 }


### PR DESCRIPTION
```bash
                       === npm audit security report ===                        
                                                                                
# Run  npm install yargs@15.0.2  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ mem                                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ yargs                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ yargs > os-locale > mem                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1084                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

Also set the engine field in package.json to `"node": ">=8"`