### PR TITLE
Wait until the file handle is closed - closes #224

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -185,7 +185,7 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, config, callback) {
     function(response) {
       response.pipe(file);
 
-      response.on('end', function() {
+      response.on('close', function() {
         fs.chmodSync(localBinary, 0700);
         setTimeout(function() {
           tunnelLauncher();


### PR DESCRIPTION
This PR prevents EXTBSY errors on Linux systems.