### PR TITLE
Fix bad console assignment

### DIFF
--- a/lib/_patch/browserstack.js
+++ b/lib/_patch/browserstack.js
@@ -37,7 +37,11 @@
     req.send(data);
   }
 
-  var browserstack_console = console || window.console || {};
+  // Change some console method to capture the logs.
+  // This must not replace the console object itself so that other console methods
+  //  from the browser or added by the tested application remain unaffected.
+  // https://github.com/browserstack/browserstack-runner/pull/199
+  var browserstack_console = window.console || {};
   browserstack_console.log = function () {
     var args = BrowserStack.util.toArray(arguments).map(BrowserStack.util.inspect);
     post('/_log/', { arguments: args }, function () {});
@@ -54,6 +58,7 @@
   BrowserStack.worker_uuid = getParameterByName('_worker_key');
 
   window.BrowserStack = BrowserStack;
+  // If the browser didn't have a console object (old IE), then this will create it.
+  // Otherwise this is a no-op as it will assign the same object it already held.
   window.console = browserstack_console;
-  console = browserstack_console;
 })();


### PR DESCRIPTION
Follows-up 826d2c7c9edbc4.

Before that commit, the reason global "console" was globbered is that the
`var console` part of the inner `var console = {}` assignment was hosted by
the JavaScript engine. Thus the variable always existed in the local scope as
type "undefined", and so the conditional check never saw the real console, and
always created a custom one. Thus it always deleted the original console reference,
as well as any other it contained.

In commit 826d2c7c9edbc4, this was incorrectly fixed by assigning the unchecked
expression referring to `console`, thus no longer having a fallback to `{}` in older
browsers, because an unchecked reference like that throws an Uncaught ReferenceError.

As a result, browserstack-runner was unable to run in IE 9 or older.

Fixes https://github.com/browserstack/browserstack-runner/issues/161.
Fixes https://github.com/browserstack/browserstack-runner/issues/164.
Fixes https://github.com/browserstack/browserstack-runner/issues/212.