### PR TITLE
Update to js-reporters 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: node_js
 node_js:
   - 'stable'
 
-before_install:
-  - npm install -g grunt-cli jshint gulp
-
 script:
   - npm run-script test-ci
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # BrowserStack Runner
 
-[![Build Status](https://travis-ci.org/browserstack/browserstack-runner.svg?branch=master)](https://travis-ci.org/browserstack/browserstack-runner)
-
 A command line interface to run browser tests over BrowserStack.
+
+## Hotfixes from [@qunitjs/browserstack-runner](https://github.com/qunitjs/browserstack-runner):
+
+1. Fix Mocha 8+ compat. [#248](https://github.com/browserstack/browserstack-runner/issues/248)
+2. Fix QUnit.todo breakage. [#247](https://github.com/browserstack/browserstack-runner/issues/247)
 
 ## Usage
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -387,17 +387,27 @@ exports.Server = function Server(bsClient, workers, config, callback) {
 
       logger.trace('[%s] _progress', worker.id, CircularJSON.stringify(query));
 
-      if (query && query.test && query.test.errors) {
+      if (query && query.test) {
+        // Include all tests in the report
         var browserReport = getBrowserReport(browserInfo);
         browserReport.tests.push(query.test || {});
 
-        query.test.errors.forEach(function(error) {
-          logger.info('[%s] ' + chalk.red('Error:'), browserInfo, formatTraceback({
-            error: error,
-            testName: query.test.name,
-            suiteName: query.test.suiteName
-          }));
-        });
+        // Only print errors of failed tests
+        // (errors from todo tests are expected and will not be reported as
+        // "failed" to the "_report" handler either, so printing them here
+        // would create a confusing output with error printed but a success
+        // status at the end)
+        // https://github.com/browserstack/browserstack-runner/issues/247
+        if (query.test.errors && query.test.status !== 'todo') {
+          query.test.errors.forEach(function(error) {
+            logger.info('[%s] ' + chalk.red('Error:'), browserInfo, formatTraceback({
+              testName: query.test.name,
+              suiteName: query.test.suiteName,
+              status: query.test.status,
+              error: error
+            }));
+          });
+        }
       }
       response.end();
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -886,9 +886,9 @@
       "optional": true
     },
     "js-reporters": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.1.0.tgz",
-      "integrity": "sha1-yDwA/g1Mn2f5RLTt1fOylXSXzWI="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-2.1.0.tgz",
+      "integrity": "sha512-Q4GcEcPSb6ovhqp91claM3WPbSntQxbIn+3JiJgEXturys2ttWgs31VC60Yja+2unpNOH2A2qyjWFU2thCQ8sg=="
     },
     "jsbn": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "browserstack-runner",
-  "version": "0.9.5",
+  "version": "0.9.5-qunitjs.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "browserstack-runner",
-  "description": "A command line interface to run browser tests over BrowserStack",
-  "version": "0.9.5",
+  "name": "@qunitjs/browserstack-runner",
+  "description": "[Hotfix] run browser tests over BrowserStack",
+  "version": "0.9.5-qunitjs.1",
   "homepage": "https://github.com/browserstack/browserstack-runner",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "browserstack": "1.3.0",
     "chalk": "0.4.0",
     "circular-json": "0.3.1",
-    "js-reporters": "1.1.0",
+    "js-reporters": "2.1.0",
     "mime": "1.6.0",
     "resolve": "1.1.7",
     "send": "0.16.2",


### PR DESCRIPTION
* Fixes Mocha 8 compatibility.
* Fixes broken builds that use `QUnit.todo`.

Fixes #248.
Fixes #247.