### PR TITLE
Retry BSL fetch with arch=x64 for Darwin ARM64 systems

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -175,28 +175,43 @@ var Tunnel = function Tunnel(key, port, uniqueIdentifier, config, callback) {
     });
   }
 
+  function fetchTunnelBinary(retryDarwinArm64) {
+    var file = fs.createWriteStream(localBinary);
+    var isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
+    var arch = isDarwinArm64 && retryDarwinArm64 ? 'x64' : process.arch;
+    https.get('https://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal' + (windows ? '.exe' : '-' + process.platform + '-' + arch),
+    function(response) {
+      if (response.statusCode !== 200) {
+        if (isDarwinArm64 && !retryDarwinArm64) {
+          fetchTunnelBinary(true);
+        } else {
+          var message = 'Got error while downloading binary: ' + response.statusCode + ' ' + response.statusMessage;
+          logger.info(message);
+          throw new Error(message);
+        }
+      } else {
+        response.pipe(file);
+
+        response.on('end', function() {
+          fs.chmodSync(localBinary, 0700);
+          setTimeout(function() {
+            tunnelLauncher();
+          }, 100);
+        }).on('error', function(e) {
+          logger.info('Got error while downloading binary: ' + e.message);
+          throw new Error('Got error while downloading binary: ' + e.message);
+        });
+      }
+    });
+  }
+
   verifyTunnelBinary(function (exists) {
     if (exists) {
       tunnelLauncher();
       return;
     }
     logger.debug('Downloading BrowserStack Local to "%s"', localBinary);
-
-    var file = fs.createWriteStream(localBinary);
-    https.get('https://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal' + (windows ? '.exe' : '-' + process.platform + '-' + process.arch),
-    function(response) {
-      response.pipe(file);
-
-      response.on('end', function() {
-        fs.chmodSync(localBinary, 0700);
-        setTimeout(function() {
-          tunnelLauncher();
-        }, 100);
-      }).on('error', function(e) {
-        logger.info('Got error while downloading binary: ' + e.message);
-        throw new Error('Got error while downloading binary: ' + e.message);
-      });
-    });
+    fetchTunnelBinary(false);
   });
 
   return that;


### PR DESCRIPTION
As BrowserStackLocal builds are not available for Darwin `arm64` architectures but `x64` does work on them, this patch retries with the latter.

Also, if the fetch fails, the `resourceCode` is checked and an error is reported if it's not `200`.